### PR TITLE
DOC-3212: Added intro page for C5 building CorDapp tut.

### DIFF
--- a/content/en/tutorials/corda/5.0-dev-preview-1/os/build-basic-cordapp/c5-basic-cordapp-intro.md
+++ b/content/en/tutorials/corda/5.0-dev-preview-1/os/build-basic-cordapp/c5-basic-cordapp-intro.md
@@ -11,7 +11,7 @@ menu:
 title: Building your first basic CorDapp
 ---
 
-Follow this learning path to build your first CorDapp with a step-by-step guide. This set of tutorials teaches you how to implement the functionality and features you will need to get any CorDapp up and running with the Corda 5 Developer Preview. It reinforces [best practices for building CorDapps](xxx).
+Follow this learning path to build your first CorDapp using step-by-step tutorials. You will learn how to implement the functionality and features needed to get any CorDapp up and running with the Corda 5 Developer Preview. It reinforces [best practices for building CorDapps](xxx).
 
 Code samples for this tutorial are provided in Kotlin.
 
@@ -48,13 +48,13 @@ An important feature of this CorDapp is that the voucher cannot be used more tha
 
 ## How will it work on Corda?
 
-1. Mars Express issues a voucher to Peter via a ledger transaction. In your CorDapp this voucher is called `MarsVoucher` and is a [state](../../../../../platform/corda/4.8/os/key-concepts-states.md) on the [ledger](../../../../../platform/corda/4.8/os/key-concepts-ledger.md). One transaction has been performed so far.
+1. Mars Express issues a voucher to Peter via a ledger transaction. In your CorDapp, this voucher is called `MarsVoucher` and is a [state](../../../../../platform/corda/4.8/os/key-concepts-states.md) on the [ledger](../../../../../platform/corda/4.8/os/key-concepts-ledger.md). This is the first transaction.
 
-2. When Mars Express prepares the ticket Peter requested, the company self-issues the ticket via a self-issue transaction. This is another state on the ledger - `BoardingTicket`. Two transactions have been performed so far.
+2. When Mars Express prepares the ticket Peter requested, the company self-issues the ticket via a self-issue transaction. This is another state on the ledger - `BoardingTicket`. This is the second transaction.
 
-3. Next, Peter goes to Mars Express to redeem his voucher and pick up his ticket, triggering a transaction on the ledger that consumes the `MarsVoucher` state. Three transactions have been performed so far.
+3. Next, Peter goes to Mars Express to redeem his voucher and pick up his ticket, triggering a transaction on the ledger that consumes the `MarsVoucher` state. Three transactions have now been performed.
 
-4. The `BoardingTicket` state is transferred to Peter when the `MarsVoucher` state is consumed and Mars Express gives Peter his ticket.
+4. The `BoardingTicket` state is transferred to Peter when the `MarsVoucher` state is consumed and Mars Express gives Peter his ticket. This is the fourth and final transaction. 
 
 All of these transactions are initiated by [flows](XXX).
 
@@ -63,12 +63,12 @@ All of these transactions are initiated by [flows](XXX).
 If you’ve previously built CorDapps on Corda 4, you will notice some differences when building CorDapps with the Corda 5 Developer Preview:
 
 * Modular APIs - The new APIs are modular, which lets you include or exclude the modules you need to build your CorDapp.
-* Flexibility building the client - You can create your client in any language you like. You are no longer limited to creating the client in a language targeting the JVM. We’ve also removed dependencies on Corda libraries. Additionally, RPC is now HTTP and JSON-based. You must pass JSON parameters and return types must be JSON representables if you want them to be returned over RPC.
+* Flexibility when building your client - You can create your client in any language you like. You are no longer limited to creating the client in a language targeting the JVM. We’ve also removed dependencies on Corda libraries. Additionally, RPC is now HTTP and JSON-based. You must pass JSON parameters and return types must be JSON representables if you want them to be returned over RPC.
 * Corda Services - You now use the `@CordaInject` annotation to add any Corda Service to your CorDapp. This replaces everything that was in `FlowLogic`, `ServiceHub`, and all custom Corda Services.
 * Corda package files and Corda package bundles (`.cpk` and `.cpb`) - Corda package files are the standard way to distribute CorDapps for Corda 5 Developer Preview. Corda package bundles are composed of multiple Corda package files. They are bundled in preparation for deployment.
 * Testing changes - Integration and unit testing your CorDapp is now easier.
 
-These changes will be covered in more detail in the tutorial for each topic. Contracts in the Corda 5 Developer Preview are implemented in the same way as in Corda 4.
+More details about these changes are covered in the tutorial for each topic. Contracts in the Corda 5 Developer Preview are implemented in the same way as in Corda 4.
 
 ## Next steps
 


### PR DESCRIPTION
This PR replaces an outdated PR that was closed here: https://github.com/corda/corda-docs-portal/pull/129