### PR TITLE
DOC-36 Explain why key entries are stored locally when using an HSM

### DIFF
--- a/content/en/platform/corda/4.5/enterprise/node/operating/cryptoservice-configuration.md
+++ b/content/en/platform/corda/4.5/enterprise/node/operating/cryptoservice-configuration.md
@@ -14,15 +14,15 @@ weight: 2
 
 # Using an HSM with Corda Enterprise
 
-By default, the private keys that belong to the node CA,legal identity and TLS are stored in key store files in the node’s certificates
+By default, the private keys that belong to the node CA, legal identity and TLS are stored in key store files in the node’s certificates
 directory. Users may wish to instead store this key in a hardware security module (HSM) or similar.
 
 See the [Hardware Security Modules (HSM)](../../platform-support-matrix.md#supported-hsms) for supported HSMs and their features.
 
 The cryptographic operations that are performed by the HSM are key generation and signing. The private key material is
 stored in the HSM if the node is configured to use an HSM. The public keys are stored in the HSM (if configured for the node)
-and the respective key stores, which is the node key store (nodekeystore.jks) for the node CA key (nodeca) and legal identity
-(identity-private-key). The certificate chain is stored in the key store with a dummy private key as the Java API does not
+and the respective key stores, which is the node key store (`nodekeystore.jks`) for the node CA key (`nodeca`) and legal identity
+(`identity-private-key`). The certificate chain is stored in the key store with a dummy private key as the Java API does not
 allow to create an entry for a certificate chain without a private key. The certificate chain is not stored in the HSM.
 
 {{< note >}}
@@ -30,8 +30,8 @@ The dummy private key entry does not contain any sensitive private key data.
 
 {{< /note >}}
 
-Operations involving the private keys (e.g., signature generation) will be delegated by the node to the HSMs, while operations
-involving the public keys (e.g., signature verification) will be performed by the node.
+Operations involving the private keys (for example, signature generation) will be delegated by the node to the HSMs, while operations
+involving the public keys (for example, signature verification) will be performed by the node.
 
 A Corda node, including a notary node, must have its node CA and legal identity keys in the same key store or HSM.
 Splitting these keys across a combination of different key stores and HSMs is not supported. TLS keys can be configured
@@ -201,7 +201,7 @@ credentials: "password"
 
 When starting Corda the environment variables `FXPKCS11_CFG` and `FXPKCS11_MODULE` need to be set as detailed in Futurex’s
 documentation. Corda must be running with the system property `java.library.path` pointing to the directory that contains
-the FutureX binaries (e.g. `libfxjp11.so` for Linux). Additionally, The JAR containing the Futurex JCA provider (version 3.1)
+the FutureX binaries (for example, `libfxjp11.so` for Linux). Additionally, The JAR containing the Futurex JCA provider (version 3.1)
 must be put on the class path, or copied to the node’s `drivers` directory. The following versions should be used for the
 required Futurex libraries: 3.1 for the PKCS#11 library and 1.17 for the Futurex JCA library.
 
@@ -397,7 +397,7 @@ See [Install and Use the AWS CloudHSM Software Library for Java](https://docs.aw
 for the list of supported operating systems.
 {{< /note >}}
 
-In the ``node.conf``, the ``cryptoServiceName`` needs to be set to "AWS_CLOUD", and ``cryptoServiceConf`` should contain
+In the `node.conf`, the `cryptoServiceName` needs to be set to "AWS_CLOUD", and `cryptoServiceConf` should contain
 the path to a configuration file, the content of which is explained further down.
 
 ```text
@@ -429,7 +429,7 @@ In addition to the configuration, the following steps are required:
 
 1. `cloudhsm-3.2.1.jar` from AWS CloudHSM Software Library for Java needs to be placed in the node’s `drivers` folder.
 2. Corda must be running with the system property `java.library.path` pointing to the directory that contains the AWS CloudHSM
-   JCA provider binaries (e.g. ``libcaviumjca.so`` for Linux). For example:
+   JCA provider binaries (for instance, `libcaviumjca.so` for Linux). For example:
 ```text
 java -Djava.library.path=/opt/cloudhsm/lib -jar corda.jar
 ```

--- a/content/en/platform/corda/4.6/enterprise/node/operating/cryptoservice-configuration.md
+++ b/content/en/platform/corda/4.6/enterprise/node/operating/cryptoservice-configuration.md
@@ -14,19 +14,19 @@ weight: 2
 
 # Using an HSM with Corda Enterprise
 
-By default, the private keys that belong to the node CA,legal identity and TLS are stored in key store files in the node’s certificates
+By default, the private keys that belong to the node CA, legal identity and TLS are stored in key store files in the node’s certificates
 directory. Users may wish to instead store this key in a hardware security module (HSM) or similar.
 
 See the [Hardware Security Modules (HSM)](../../platform-support-matrix.md#supported-hsms) for supported HSMs and their features.
 
 The cryptographic operations that are performed by the HSM are key generation and signing. The private key material is
 stored in the HSM if the node is configured to use an HSM. The public keys are stored in the HSM (if configured for the node)
-and the respective key stores, which is the node key store (nodekeystore.jks) for the node CA key (nodeca) and legal identity
-(identity-private-key). The certificate chain is stored in the key store with a dummy private key as the Java API does not
+and the respective key stores, which is the node key store (`nodekeystore.jks`) for the node CA key (`nodeca`) and legal identity
+(`identity-private-key`). The certificate chain is stored in the key store with a dummy private key as the Java API does not
 allow to create an entry for a certificate chain without a private key. The certificate chain is not stored in the HSM.
 
-Operations involving the private keys (e.g. signature generation) will be delegated by the node to the HSMs, while operations
-involving the public keys (e.g. signature verification) will be performed by the node.
+Operations involving the private keys (for example, signature generation) will be delegated by the node to the HSMs, while operations
+involving the public keys (for example, signature verification) will be performed by the node.
 
 {{< note >}}
 The dummy private key entry does not contain any sensitive private key data.
@@ -186,7 +186,7 @@ credentials: "password"
 ```
 
 When starting Corda the environment variables `FXPKCS11_CFG` and `FXPKCS11_MODULE` need to be set as detailed in Futurex’s documentation.
-Corda must be running with the system property `java.library.path` pointing to the directory that contains the Futurex binaries (e.g. `libfxjp11.so` for Linux).
+Corda must be running with the system property `java.library.path` pointing to the directory that contains the Futurex binaries (for example, `libfxjp11.so` for Linux).
 Additionally, The JAR containing the Futurex JCA provider (version 3.1) must be put on the class path, or copied to the node’s `drivers` directory.
 The following versions should be used for the required Futurex libraries: 3.1 for the PKCS#11 library and 1.17 for the Futurex JCA library.
 

--- a/content/en/platform/corda/4.7/enterprise/node/operating/cryptoservice-configuration.md
+++ b/content/en/platform/corda/4.7/enterprise/node/operating/cryptoservice-configuration.md
@@ -14,15 +14,15 @@ weight: 2
 
 # Using an HSM with Corda Enterprise
 
-By default, the private keys that belong to the node CA,legal identity and TLS are stored in key store files in the node’s
+By default, the private keys that belong to the node CA, legal identity and TLS are stored in key store files in the node’s
 certificates directory. Users may wish to instead store this key in a hardware security module (HSM) or similar.
 
 See the [Hardware Security Modules (HSM)](../../platform-support-matrix.md#supported-hsms) for supported HSMs and their features.
 
 The cryptographic operations that are performed by the HSM are key generation and signing. The private key material is
 stored in the HSM if the node is configured to use an HSM. The public keys are stored in the HSM (if configured for the node)
-and the respective key stores, which is the node key store (nodekeystore.jks) for the node CA key (nodeca) and legal identity
-(identity-private-key). The certificate chain is stored in the key store with a dummy private key as the Java API does not
+and the respective key stores, which is the node key store (`nodekeystore.jks`) for the node CA key (`nodeca`) and legal identity
+(`identity-private-key`). The certificate chain is stored in the key store with a dummy private key as the Java API does not
 allow to create an entry for a certificate chain without a private key. The certificate chain is not stored in the HSM.
 
 {{< note >}}
@@ -30,8 +30,8 @@ The dummy private key entry does not contain any sensitive private key data.
 
 {{< /note >}}
 
-Operations involving the private keys (e.g., signature generation) will be delegated by the node to the HSMs, while operations
-involving the public keys (e.g., signature verification) will be performed by the node.
+Operations involving the private keys (for example, signature generation) will be delegated by the node to the HSMs, while operations
+involving the public keys (for example, signature verification) will be performed by the node.
 
 A Corda node, including a notary node, must have its node CA and legal identity keys in the same key store or HSM.
 Splitting these keys across a combination of different key stores and HSMs is not supported. TLS keys can be configured
@@ -185,7 +185,7 @@ credentials: "password"
 ```
 
 When starting Corda the environment variables `FXPKCS11_CFG` and `FXPKCS11_MODULE` need to be set as detailed in Futurex’s documentation.
-Corda must be running with the system property `java.library.path` pointing to the directory that contains the Futurex binaries (e.g. `libfxjp11.so` for Linux).
+Corda must be running with the system property `java.library.path` pointing to the directory that contains the Futurex binaries (for example, `libfxjp11.so` for Linux).
 Additionally, The JAR containing the Futurex JCA provider (version 3.1) must be put on the class path, or copied to the node’s `drivers` directory.
 The following versions should be used for the required Futurex libraries: 3.1 for the PKCS#11 library and 1.17 for the Futurex JCA library.
 

--- a/content/en/platform/corda/4.8/enterprise/node/operating/cryptoservice-configuration.md
+++ b/content/en/platform/corda/4.8/enterprise/node/operating/cryptoservice-configuration.md
@@ -14,7 +14,7 @@ weight: 2
 
 # Using an HSM with Corda Enterprise
 
-By default, the private keys that belong to the node CA,legal identity and TLS are stored in key store files in the node’s certificates
+By default, the private keys that belong to the node CA, legal identity and TLS are stored in key store files in the node’s certificates
 directory. Users may wish to instead store this key in a hardware security module (HSM) or similar.
 
 
@@ -22,8 +22,8 @@ See the [Hardware Security Modules (HSM)](../../platform-support-matrix.md#suppo
 
 The cryptographic operations that are performed by the HSM are key generation and signing. The private key material is
 stored in the HSM if the node is configured to use an HSM. The public keys are stored in the HSM (if configured for the node)
-and the respective key stores, which is the node key store (nodekeystore.jks) for the node CA key (nodeca) and legal identity
-(identity-private-key). The certificate chain is stored in the key store with a dummy private key as the Java API does not
+and the respective key stores, which is the node key store (`nodekeystore.jks`) for the node CA key (`nodeca`) and legal identity
+(`identity-private-key`). The certificate chain is stored in the key store with a dummy private key as the Java API does not
 allow to create an entry for a certificate chain without a private key. The certificate chain is not stored in the HSM.
 
 {{< note >}}
@@ -31,8 +31,8 @@ The dummy private key entry does not contain any sensitive private key data.
 
 {{< /note >}}
 
-Operations involving the private keys (e.g., signature generation) will be delegated by the node to the HSMs, while operations
-involving the public keys (e.g., signature verification) will be performed by the node.
+Operations involving the private keys (for example, signature generation) will be delegated by the node to the HSMs, while operations
+involving the public keys (for example, signature verification) will be performed by the node.
 
 A Corda node, including a notary node, must have its node CA and legal identity keys in the same key store or HSM.
 Splitting these keys across a combination of different key stores and HSMs is not supported. TLS keys can be configured
@@ -187,7 +187,7 @@ credentials: "password"
 ```
 
 When starting Corda the environment variables `FXPKCS11_CFG` and `FXPKCS11_MODULE` need to be set as detailed in Futurex’s documentation.
-Corda must be running with the system property `java.library.path` pointing to the directory that contains the FutureX binaries (e.g. `libfxjp11.so` for Linux).
+Corda must be running with the system property `java.library.path` pointing to the directory that contains the FutureX binaries (for example, `libfxjp11.so` for Linux).
 Additionally, The JAR containing the Futurex JCA provider (version 3.1) must be put on the class path, or copied to the node’s `drivers` directory.
 The following versions should be used for the required Futurex libraries: 3.1 for the PKCS#11 library and 1.17 for the Futurex JCA library.
 


### PR DESCRIPTION
Updated introduction content as per JIRA and added a note. A table is added in config section as per JIRA request.