### PR TITLE
DOC-3114 Updated search index string and google analytics ID in config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -93,9 +93,9 @@ default_tab = "java"
 ogimage = "/images/png/corda.png"
 
 # hack - these values are asigned in global.html
-algolia_appId = "UX2KMUWFAL"
+algolia_appId = "283616090"
 algolia_apiKey = "d30af47c430efcbae42aa7e855dbf164"
-algolia_index = "docs.r3.com"
+algolia_index = "crawler_docs.r3.com"
 
 googleTagManagerID = "G-NCYRYSGJ7C"
 


### PR DESCRIPTION
DOC-3114 Updated search index string and google analytics ID in `config.toml`