### PR TITLE
DOC-3118 Fixed links in Get Started landing page and an issue with API ref menu item in DP1 section

### DIFF
--- a/content/en/get-started/_index.md
+++ b/content/en/get-started/_index.md
@@ -15,8 +15,8 @@ title: Get started
 
 To get started with an R3 trust technology product, choose from:
 
-* [Corda and Corda Enterprise](getting-started-with-corda-4.md) - the latest commercially available versions of the Corda platform.
+* [Corda and Corda Enterprise](../en/get-started/getting-started-with-corda-4.md) - the latest commercially available versions of the Corda platform.
 
-* [Corda 5 Developer Preview](getting-started-with-corda-5.md) - an early look at Corda 5, the next version of Corda. Use this for local development and building experimental, non-commercial CorDapps.
+* [Corda 5 Developer Preview](../en/get-started/getting-started-with-corda-5.md) - an early look at Corda 5, the next version of Corda. Use this for local development and building experimental, non-commercial CorDapps.
 
 * [Conclave](https://docs.conclave.net/) - R3's new confidential computing solution.

--- a/content/en/platform/corda/5.0-dev-preview-1/api-ref/overview.md
+++ b/content/en/platform/corda/5.0-dev-preview-1/api-ref/overview.md
@@ -1,13 +1,12 @@
 ---
-date: '2020-09-10'
+date: '2021-04-24T00:00:00Z'
 title: "API reference documentation"
 menu:
   corda-5-dev-preview:
     identifier: corda-5-dev-preview-1-api-reference-docs
+    name: "API reference documentation"
     weight: 9850
 section_menu: corda-5-dev-preview
-description: >
-    Documentation for the Corda 5 Dev Preview API references.
 ---
 
 Full documentation for the Corda 5 Developer Preview APIs can be found in the [API reference for Corda](/en/api-ref.html).


### PR DESCRIPTION
DOC-3118 Fixed links in Get Started landing page and an issue with API ref menu item in DP1 section