### PR TITLE
DOC-3121 DOC-3331 DOC-3330 DOC-3326 DOC-3325 DOC-3327 Various fixes

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -74,7 +74,7 @@ algolia_apiKey = "d30af47c430efcbae42aa7e855dbf164"
 algolia_index = "crawler_docs.r3.com_docsearch"
 
 # See https://gohugo.io/templates/internal/#google-analytics
-googleAnalytics = "UA-87760032-7"
+googleAnalytics = "283616090"
 
 [module]
   [[module.mounts]]

--- a/content/en/announcements/_index.md
+++ b/content/en/announcements/_index.md
@@ -33,19 +33,19 @@ Head over to the <a href="https://www.cordacon.com/" target="_blank">CordaCon 20
 
 **28th September 2021**
 
-The entire R3 documentation has moved home - **doc.r3.com** - and you are already in!
+The entire R3 product documentation about Corda has moved home - to **docs.r3.com** - and you are already in!
 
 Welcome to the palace of Corda knowledge - the single source of truth for everything you need to know about Corda!
 
 Alongside the brand new site design and the user experience perks it brings, we have made a few more significant changes in the background. To name a few:
 
-* We have massively refactored the entire documentation sets for Corda 4.8 (open source), Corda Enterprise 4.8, and Corda Enterprise Network Manager (CENM) 1.5! The work on this project will continue for a little longer in the next few months, however we truly hope that this content is now more readable, better structured, and overall much more useful and easier to follow than before.
-* We have brought over the complete API documentation reference content to [docs.r3.com](https://docs.r3.com/en/api-ref.html), and we have added the Corda 5 Developer Preview public API reference too.
-* In the near future we are planning to improve the Conclave documentation content and migrate it to [doc.r3.com](https://docs.r3.com).
-* We have added **dark mode** to the docs - just click the icon at the top right corner of any docs page!
-* We plan to expand the scope of the content we pubish on [doc.r3.com](https://docs.r3.com). In the upcoming year, we will be bringing you more useful tutorials, enriched and improved content based on your feedback and our own user research and analytics, and more interactive learning paths to support the main documentation.
+* We have massively refactored the documentation sets for Corda 4.8 (open source), Corda Enterprise 4.8, and Corda Enterprise Network Manager (CENM) 1.5! The work on this project will continue for a little longer in the next few months, however we truly hope that this content is now more readable, better structured, and overall much more useful and easier to follow than before.
+* We have brought over the Corda 4 API reference to [docs.r3.com](https://docs.r3.com/en/api-ref.html), and we have added the Corda 5 Developer Preview public API reference too.
+* In the near future we are planning to improve the [Conclave documentation](https://docs.conclave.com) content and migrate it to [docs.r3.com](https://docs.r3.com).
+* We have added **dark mode** to the docs - just click the icon at the top right corner of any docs page to switch between modes!
+* We are planning to expand the scope of the content we publish on [docs.r3.com](https://docs.r3.com). In the upcoming year, we will be bringing you more and more useful tutorials, enriched and improved content based on your feedback and our own user research and analytics, and more interactive learning paths to support the main documentation.
 
-Tell us what you think about the docs and the new site on <a href="https://cordaledger.slack.com/archives/C01Q3RQ7E8M">slack</a> and <a href="mailto:corda-docs@r3.com">over email</a>.
+Tell us what you think about the docs and the new site on [slack](https://cordaledger.slack.com/archives/C01Q3RQ7E8M) and [over email](mailto:corda-docs@r3.com).
 
 ## The Corda 5 Developer Preview is here!
 
@@ -55,7 +55,7 @@ Build and deploy CorDapps locally with this first preview version of Corda 5 - t
 
 Experiment with the new modular API, HTTPS node interaction, and CorDapp packaging.
 
-Build your first test CorDapp with the Corda 5 Developer Preview - start [here](../platform/corda/5.0-dev-preview-1/).
+Build your first test CorDapp with the Corda 5 Developer Preview - start [here](../../en/platform/corda/5.0-dev-preview-1.html).
 
 ## Join the R3 Developer Platform
 
@@ -63,4 +63,4 @@ Build your first test CorDapp with the Corda 5 Developer Preview - start [here](
 
 Join the most powerful blockchain and confidential computing community for developers. Build your knowledge of blockchain and confidential computing by accessing R3’s developer resources, open-source projects, additional support from R3 developers, and documentation.
 
-<a href="https://developer.r3.com/" target="_blank">Join the R3 Developer Platform here</a>.
+Join the [R3 Developer Platform](https://developer.r3.com/).

--- a/content/en/apps/bankinabox/bank-index.md
+++ b/content/en/apps/bankinabox/bank-index.md
@@ -5,11 +5,7 @@ menu:
   apps:
     identifier: bankinabox
     name: Bank in a Box
-aliases:
-- /docs/apps/bankinabox.html
-tags:
-- Bank in a Box
-- API
+    weight: 2000
 title: Bank in a Box
 weight: 100
 ---

--- a/content/en/apps/reissuance/state-reissuance.md
+++ b/content/en/apps/reissuance/state-reissuance.md
@@ -9,13 +9,11 @@ menu:
 title: State reissuance
 ---
 
-# State reissuance CorDapps
-
 The state reissuance CorDapps listed below provide a state reissuance mechanism that enables you to break transaction backchains by reissuing a state with a guaranteed state replacement.
 
-Read more about reissuing states [here](../../../platform/corda/4.8/open-source/reissuing-states.md).
+Read more about reissuing states [here](../../../en/platform/corda/4.8/open-source/reissuing-states.md).
 
-## Sample CorDapps
+Sample CorDapps:
 
 * State reissuance CorDapp: [https://github.com/corda/reissue-cordapp](https://github.com/corda/reissue-cordapp).
 

--- a/content/en/platform/conclave/_index.md
+++ b/content/en/platform/conclave/_index.md
@@ -6,8 +6,6 @@ menu:
     name: Conclave
     identifier: homepage-conclave
     weight: 90000
-  conclave:
-    weight: 10
 project: conclave
 version: 'conclave'
 title: Conclave

--- a/content/en/release-notes/_index.md
+++ b/content/en/release-notes/_index.md
@@ -7,8 +7,6 @@ menu:
     weight: -550
     identifier: homepage-releases
     project: releases
-  releases:
-    weight: 10
 project: releases
 version: 'releases'
 title: Releases

--- a/content/en/tools/ledgergraph/ledgergraph-index.md
+++ b/content/en/tools/ledgergraph/ledgergraph-index.md
@@ -3,20 +3,20 @@ date: '2021-04-24T00:00:00Z'
 section_menu: tools
 menu:
   tools:
-    name: Ledgergraph
+    name: LedgerGraph
     weight: 800
     identifier: tools-ledgergraph
-title: Ledgergraph
+title: LedgerGraph
 ---
 
-# Ledgergraph
+# LedgerGraph
 
 LedgerGraph is a CorDapp you can use to get in-memory access to transaction data. Transaction information is kept in a graph structure on any node where LedgerGraph is installed. As not all transactions are related to all other transactions, there can actually be multiple components in the graph: each a directed acyclic graph (DAG).
 
 LedgerGraph enables other CorDapps, such as the set of Collaborative Recovery CorDapps, to have near real-time access to data concerning all of a node’s transactions and their relationships. Without it, many operations would be unacceptably slow and impractical.
 
 {{< warning >}}
-LedgerGraph is a dependency for the set of [Collaborative Recovery](../../collaborative-recovery/ci-index.md) CorDapps V1.1 and above. If you are using an earlier version of Collaborative Recovery, you should not install the stand-alone LedgerGraph.
+LedgerGraph is a dependency for the set of [Collaborative Recovery](../../../en/tools/collaborative-recovery/ci-index.md) CorDapps V1.1 and above. If you are using an earlier version of Collaborative Recovery, you should not install the stand-alone LedgerGraph.
 {{< /warning >}}
 
 Read the full documentation about [LedgerGraph](../../../en/platform/corda/4.8/enterprise/node/operating/ledger-graph.md).

--- a/themes/doks/assets/js/vendor/googleanalytics.js
+++ b/themes/doks/assets/js/vendor/googleanalytics.js
@@ -19,6 +19,6 @@ export function googleAnalytics() {
         "ga"
     );
 
-    window.ga("create", "UA-87760032-7", "auto");
+    window.ga("create", "283616090", "auto");
     window.ga("send", "pageview");
 }

--- a/themes/doks/static/js/home.js
+++ b/themes/doks/static/js/home.js
@@ -1,6 +1,6 @@
 $(document).ready(function(){
   $('#home-carousel').slick({
     'dots': true,
-    'autoplay': true,
+    'autoplay': false,
   });
 });


### PR DESCRIPTION
* DOC-3121 Updated GA code
* DOC-3331 Fixed some typos and links in Announcements page
* DOC-3330 Updated tools > ledgergraph page - capitalisation and a broken link
* DOC-3326 Updated state reissuance page in Apps section - removed RHS context menu, fixed a link, and updated front matterin bankinabox-index
* DOC-3325 Removed "home" link in LHS context menu in conclave and releases sections as these are single static pages with no child pages
* DOC-3327 Disabled autoplay for carousel slides