### PR TITLE
DOC-3406: Fixed some links in CE 4.5 under Developing CorDapps

### DIFF
--- a/content/en/platform/corda/4.5/enterprise/cordapps/api-contract-constraints.md
+++ b/content/en/platform/corda/4.5/enterprise/cordapps/api-contract-constraints.md
@@ -143,10 +143,10 @@ Example 2:
 
 
 Information on blacklisting attachment signing keys can be found in the
-[node configuration documentation](../node/setup/corda-configuration-file.md#corda-configuration-file-blacklisted-attachment-signer-keys).
+[node configuration documentation](../../../../../../../en/platform/corda/4.5/enterprise/node/setup/corda-configuration-file.html#corda-configuration-file-blacklisted-attachment-signer-keys).
 
 More information on how to sign an app directly from Gradle can be found in the
-[CorDapp Jar signing](cordapp-build-systems.md#cordapp-build-system-signing-cordapp-jar-ref) section of the documentation.
+[CorDapp Jar signing](../../../../../../../en/platform/corda/4.5/enterprise/cordapps/cordapp-build-systems.html#cordapp-build-system-signing-cordapp-jar-ref) section of the documentation.
 
 
 ## Using Signature Constraints in transactions

--- a/content/en/platform/corda/4.5/enterprise/cordapps/api-flows.md
+++ b/content/en/platform/corda/4.5/enterprise/cordapps/api-flows.md
@@ -741,7 +741,7 @@ transaction fail to verify it, or the receiving flow (the finality handler) fail
 all parties have the correct up to date view of the ledger (a condition where eventual consistency between participants takes longer than is
 normally the case under Corda’s [eventual consistency model](https://en.wikipedia.org/wiki/Eventual_consistency)). To recover from this scenario,
 the receiver’s finality handler will automatically be sent to the node-flow-hospital where it’s suspended and retried from its last checkpoint
-upon node restart, or according to other conditional retry rules explained in [flow hospital runtime behaviour](../node/node-flow-hospital.md#flow-hospital-runtime).
+upon node restart, or according to other conditional retry rules explained in [flow hospital runtime behaviour](../../../../../../../en/platform/corda/4.5/enterprise/node/node-flow-hospital.html#flow-hospital-runtime).
 This gives the node operator the opportunity to recover from the error. Until the issue is resolved the node will continue to retry the flow
 on each startup. Upon successful completion by the receiver’s finality flow, the ledger will become fully consistent once again.
 
@@ -1169,7 +1169,7 @@ Threading needs to be explicitly handled when using `FlowExternalAsyncOperation`
 thread pool.
 
 {{< note >}}
-The size of the external operation thread pool can be configured, see [the node configuration documentation](../node/setup/corda-configuration-file.md#corda-configuration-flow-external-operation-thread-pool-size).
+The size of the external operation thread pool can be configured, see [the node configuration documentation](../../../../../../../en/platform/corda/4.5/enterprise/node/setup/corda-configuration-file.html#corda-configuration-flow-external-operation-thread-pool-size).
 
 {{< /note >}}
 Below is an example of how `FlowExternalOperation` can be called from a flow to run an operation on a new thread, allowing the flow to suspend:

--- a/content/en/platform/corda/4.5/enterprise/cordapps/cordapp-compatibility.md
+++ b/content/en/platform/corda/4.5/enterprise/cordapps/cordapp-compatibility.md
@@ -21,7 +21,7 @@ This allows CorDapps to be developed for compatibility between Corda and Corda E
 In order to develop a CorDapp for compatibility between Corda and Corda Enterprise follow these steps:
 
 
-* Ensure your CorDapp is designed per [Structuring a CorDapp](writing-a-cordapp.md) and annotated according to [CorDapp separation](cordapp-build-systems.md#cordapp-separation-ref).
+* Ensure your CorDapp is designed per [Structuring a CorDapp](writing-a-cordapp.md) and annotated according to [CorDapp separation](../../../../../../../en/platform/corda/4.5/enterprise/cordapps/cordapp-build-systems.html#cordapp-separation-ref).
 In particular, it is critical to separate the consensus-critical parts of your application (contracts, states and their dependencies) from
 the rest of the business logic (flows, APIs, etc).
 The former - the **CorDapp kernel** - is the Jar that will be attached to transactions creating/consuming your states and is the Jar
@@ -29,7 +29,7 @@ that any node on the network verifying the transaction must execute.
 
 {{< note >}}
 It is also important to understand how to manage any dependencies a CorDapp may have on 3rd party libraries and other CorDapps.
-Please read [Setting your dependencies](cordapp-build-systems.md#cordapp-dependencies-ref) to understand the options and recommendations with regards to correctly Jar’ing CorDapp dependencies.
+Please read [Setting your dependencies](../../../../../../../en/platform/corda/4.5/enterprise/cordapps/cordapp-build-systems.html#cordapp-dependencies-ref) to understand the options and recommendations with regards to correctly Jar’ing CorDapp dependencies.
 
 {{< /note >}}
 
@@ -37,7 +37,7 @@ Please read [Setting your dependencies](cordapp-build-systems.md#cordapp-depende
 depend on the `corda-core` package from the Corda Open Source distribution.
 
 {{< note >}}
-As of Corda 4 it is recommended to use [CorDapp Jar signing](cordapp-build-systems.md#cordapp-build-system-signing-cordapp-jar-ref) to leverage the new signature constraints functionality.
+As of Corda 4 it is recommended to use [CorDapp Jar signing](../../../../../../../en/platform/corda/4.5/enterprise/cordapps/cordapp-build-systems.html#cordapp-build-system-signing-cordapp-jar-ref) to leverage the new signature constraints functionality.
 
 {{< /note >}}
 

--- a/content/en/platform/corda/4.5/enterprise/cordapps/database-management.md
+++ b/content/en/platform/corda/4.5/enterprise/cordapps/database-management.md
@@ -18,7 +18,7 @@ Similarly, when a new version of a CorDapp is installed, its database schema may
 but the existing data needs to be preserved or changed accordingly.
 
 In Corda Enteprise, CorDapps’ custom tables are created or upgraded automatically based on
-Database Management Scripts written in [Liquibase](../node/operating/node-database.md#liquibase-ref) format and embedded in CorDapp JARs.
+Database Management Scripts written in [Liquibase](../../../../../../../en/platform/corda/4.5/enterprise/node/operating/node-database.html#liquibase-ref) format and embedded in CorDapp JARs.
 For Corda Enterpise, any CorDapp having custom tables (`MappedSchema`)  needs to contain a matching Database Management Script, the script should be created during CorDapp development.
 
 

--- a/content/en/platform/corda/4.5/enterprise/cordapps/getting-set-up.md
+++ b/content/en/platform/corda/4.5/enterprise/cordapps/getting-set-up.md
@@ -60,7 +60,7 @@ If you'd prefer to install Gradle manually, navigate to [Gradle](https://gradle.
 
 First, run the [example CorDapp](tutorial-cordapp.md).
 
-Next, read through the [Corda Key Concepts](key-concepts.md) to understand how Corda works.
+Next, read through the [Corda Key Concepts](../../../../../../../en/platform/corda/4.5/enterprise/open-source/key-concepts.md) to understand how Corda works.
 
 By then, you’ll be ready to start writing your own CorDapps. You may want to refer to the
 API documentation, the [flow cookbook](flow-cookbook.md) and the

--- a/content/en/platform/corda/4.5/enterprise/cordapps/tutorial-cordapp.md
+++ b/content/en/platform/corda/4.5/enterprise/cordapps/tutorial-cordapp.md
@@ -443,7 +443,7 @@ The nodes can be configured to communicate as a network even when distributed ac
 * For each node, open its `node.conf` file and change `localhost` in its `p2pAddress` to the IP address of the machine
 where the node will be run (e.g. `p2pAddress="10.18.0.166:10007"`)
 * These changes require new node-info files to be distributed amongst the nodes. Use the network bootstrapper tool
-(see [Network Bootstrapper](network-bootstrapper.md)) to update the files and have them distributed locally:`java -jar network-bootstrapper.jar /build/nodes`
+(see [Network Bootstrapper](../../../../../../../en/platform/corda/4.5/enterprise/open-source/network-bootstrapper.md)) to update the files and have them distributed locally:`java -jar network-bootstrapper.jar /build/nodes`
 * Move the node folders to their individual machines (for example, using a USB key). It is important that none of the
 nodes - including the notary - end up on more than one machine. Each computer should also have a copy of `runnodes`
 and `runnodes.bat`. For example, you may end up with the following layout:
@@ -468,7 +468,7 @@ the nodes’ databases and if two nodes share the same H2 port, the process will
 
 ## Testing the CorDapp
 
-Corda provides several frameworks for writing unit and integration tests for CorDapps. To access test flows in IntelliJ, select an option from the ‘Run Configurations’ dropdown next to the hammer icon.  For a general guide, see [[Running tests in IntelliJ](testing.md#tutorial-cordapp-alternative-test-runners).
+Corda provides several frameworks for writing unit and integration tests for CorDapps. To access test flows in IntelliJ, select an option from the ‘Run Configurations’ dropdown next to the hammer icon.  For a general guide, see [[Running tests in IntelliJ](../../../../../../../en/platform/corda/4.5/enterprise/testing.html#tutorial-cordapp-alternative-test-runners).
 
 ### Integration tests
 


### PR DESCRIPTION
Pages to review:

- Getting set up for CorDapp development
- Running a sample CorDapp
- CorDapp compatibility between Corda and Corda Enterprise
- Writing CorDapp contracts -> Contract Constraints
- Writing CorDapp states -> Database management scripts
- Writing CorDapp Flows