### PR TITLE
NOTICK: added an alias for CDL main page

### DIFF
--- a/content/en/tools/cdl/cdl-index.md
+++ b/content/en/tools/cdl/cdl-index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /docs/cdl/cdl.html
 date: '2021-04-24T00:00:00Z'
 menu:
   tools:

--- a/makefile
+++ b/makefile
@@ -65,6 +65,9 @@ prod-docker-image: prod-hugo-build ## Create the prod docker image
 prod-docker-serve: prod-docker-image ## Run the nginx container locally on port 8888
 	$(DOCKER_RUN) -it -p "8888:80" $(PROD_IMAGE)
 
+prod-hugo-serve: prod-hugo-build ## Start Hugo and serve production build
+	$(DOCKER_RUN) --env HOME=/tmp -u $$(id -u):$$(id -g) -it -p 1313:1313 $(HUGO_DOCKER_IMAGE) npm run server
+
 #######################################################################################################################
 #  Main target for CI:
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "hugo --gc --minify",
     "build:preview": "npm run build -D -F",
     "clean": "rimraf public resources functions",
-    "server": "hugo server",
+    "server": "hugo server --buildFuture --buildDrafts --disableFastRender --bind 0.0.0.0",
     "env": "env",
     "precheck": "npm version",
     "check": "hugo version"


### PR DESCRIPTION
* make sure old `/docs/cdl/cdl.html` is directed to a new location
* new `make` target `prod-hugo-serve` to start Hugo server managed by
  npm