### PR TITLE
DOC-3439 Add missing link to network-bootstrapper in Network map page in CE 4.4 to 4.8

### DIFF
--- a/content/en/platform/corda/4.4/enterprise/network/network-map.md
+++ b/content/en/platform/corda/4.4/enterprise/network/network-map.md
@@ -72,7 +72,7 @@ Note that only HTTP OK (response code 200) is supported - any other kind of resp
 ### Additional endpoints from R3
 
 Network maps hosted by R3 or other parties using R3’s commercial network management tools typically provide some
-additional endpoints for users. These additional endpoints can be found [here](../../../cenm/1.2/network-map-overview.html).
+additional endpoints for users. These additional endpoints can be found [here](../../../../../../en/platform/corda/1.2/cenm/network-map-overview.md).
 
 HTTP is used for the network map service instead of Corda’s own AMQP based peer to peer messaging protocol to
 enable the server to be placed behind caching content delivery networks like Cloudflare, Akamai, Amazon Cloudfront and so on.
@@ -102,7 +102,7 @@ the network, along with the network parameters file and identity certificates. G
 online at once - an offline node that isn’t being interacted with doesn’t impact the network in any way. So a test
 cluster generated like this can be sized for the maximum size you may need, and then scaled up and down as necessary.
 
-More information can be found in network-bootstrapper.
+More information can be found in [Network Bootstrapper](../../../../../../en/platform/corda/4.4/enterprise/network-bootstrapper.md).
 
 
 

--- a/content/en/platform/corda/4.5/enterprise/network/network-map.md
+++ b/content/en/platform/corda/4.5/enterprise/network/network-map.md
@@ -69,7 +69,7 @@ Note that only HTTP OK (response code 200) is supported - any other kind of resp
 ### Additional endpoints from R3
 
 Network maps hosted by R3 or other parties using R3’s commercial network management tools typically provide some
-additional endpoints for users. These additional endpoints can be found [here](../../../cenm/1.3/network-map-overview.html).
+additional endpoints for users. These additional endpoints can be found [here](../../../../../../en/platform/corda/1.3/cenm/network-map-overview.md).
 
 HTTP is used for the network map service instead of Corda’s own AMQP based peer to peer messaging protocol to
 enable the server to be placed behind caching content delivery networks like Cloudflare, Akamai, Amazon Cloudfront and so on.
@@ -99,7 +99,7 @@ the network, along with the network parameters file and identity certificates. G
 online at once - an offline node that isn’t being interacted with doesn’t impact the network in any way. So a test
 cluster generated like this can be sized for the maximum size you may need, and then scaled up and down as necessary.
 
-More information can be found in network-bootstrapper.
+More information can be found in [Network Bootstrapper](../../../../../../en/platform/corda/4.5/enterprise/network-bootstrapper.md).
 
 
 

--- a/content/en/platform/corda/4.6/enterprise/network/network-map.md
+++ b/content/en/platform/corda/4.6/enterprise/network/network-map.md
@@ -80,7 +80,7 @@ The set of REST end-points for the network map service are as follows.
 ### Additional endpoints from R3
 
 Network maps hosted by R3 or other parties using R3’s commercial network management tools typically provide some
-additional endpoints for users. These additional endpoints can be found [here](../../../cenm/1.4/network-map-overview.html).
+additional endpoints for users. These additional endpoints can be found [here](../../../../../../en/platform/corda/1.4/cenm/network-map-overview.md).
 
 HTTP is used for the network map service instead of Corda’s own AMQP based peer to peer messaging protocol to
 enable the server to be placed behind caching content delivery networks like Cloudflare, Akamai, Amazon Cloudfront and so on.
@@ -110,7 +110,7 @@ the network, along with the network parameters file and identity certificates. G
 online at once - an offline node that isn’t being interacted with doesn’t impact the network in any way. So a test
 cluster generated like this can be sized for the maximum size you may need, and then scaled up and down as necessary.
 
-More information can be found in network-bootstrapper.
+More information can be found in [Network Bootstrapper](../../../../../../en/platform/corda/4.6/enterprise/network-bootstrapper.md).
 
 
 
@@ -188,7 +188,7 @@ Any CorDapp JAR that offers contracts and states in any of these packages must b
 This ensures that when a node encounters an owned contract it can uniquely identify it and knows that all other nodes can do the same.
 Encountering an owned contract in a JAR that is not signed by the rightful owner is most likely a sign of malicious behaviour, and should be reported.
 The transaction verification logic will throw an exception when this happens.
-Read more about *Package ownership* here “[Package namespace ownership](../node/deploy/env-dev.md#package-namespace-ownership)”.
+Read more about *Package ownership* here “[Package namespace ownership](../node/deploy/env-dev.html#package-namespace-ownership)”.
 
 
 
@@ -321,4 +321,4 @@ If you need to add a new notary after the network map is running:
 3. Set new network parameters.
 4. Sign the new `network-parameter`.
 
-You can also [Set up a notary in a segregated network](setup-segregated-notary.html).
+You can also [Set up a notary in a segregated network](../../../../../../en/platform/corda/4.6/enterprise/corda-network/setup-segregated-notary.md).

--- a/content/en/platform/corda/4.7/enterprise/network/network-map.md
+++ b/content/en/platform/corda/4.7/enterprise/network/network-map.md
@@ -80,7 +80,7 @@ The set of REST end-points for the network map service are as follows.
 ### Additional endpoints from R3
 
 Network maps hosted by R3 or other parties using R3’s commercial network management tools typically provide some
-additional endpoints for users. These additional endpoints can be found [here](../../../cenm/1.5/network-map-overview.html).
+additional endpoints for users. These additional endpoints can be found [here](../../../../../../en/platform/corda/1.5/cenm/network-map-overview.md).
 
 HTTP is used for the network map service instead of Corda’s own AMQP based peer to peer messaging protocol to
 enable the server to be placed behind caching content delivery networks like Cloudflare, Akamai, Amazon Cloudfront and so on.
@@ -110,7 +110,7 @@ the network, along with the network parameters file and identity certificates. G
 online at once - an offline node that isn’t being interacted with doesn’t impact the network in any way. So a test
 cluster generated like this can be sized for the maximum size you may need, and then scaled up and down as necessary.
 
-More information can be found in network-bootstrapper.
+More information can be found in [Network Bootstrapper](../../../../../../en/platform/corda/4.7/enterprise/network-bootstrapper.md).
 
 
 
@@ -188,7 +188,7 @@ Any CorDapp JAR that offers contracts and states in any of these packages must b
 This ensures that when a node encounters an owned contract it can uniquely identify it and knows that all other nodes can do the same.
 Encountering an owned contract in a JAR that is not signed by the rightful owner is most likely a sign of malicious behaviour, and should be reported.
 The transaction verification logic will throw an exception when this happens.
-Read more about *Package ownership* here “[Package namespace ownership](../node/deploy/env-dev.md#package-namespace-ownership)”.
+Read more about *Package ownership* here “[Package namespace ownership](../node/deploy/env-dev.html#package-namespace-ownership)”.
 
 
 
@@ -321,4 +321,4 @@ If you need to add a new notary after the network map is running:
 3. Set new network parameters.
 4. Sign the new `network-parameter`.
 
-You can also [Set up a notary in a segregated network](setup-segregated-notary.html).
+You can also [Set up a notary in a segregated network](../../../../../../en/platform/corda/4.7/enterprise/corda-network/setup-segregated-notary.md).

--- a/content/en/platform/corda/4.8/enterprise/network/network-map.md
+++ b/content/en/platform/corda/4.8/enterprise/network/network-map.md
@@ -110,7 +110,7 @@ the network, along with the network parameters file and identity certificates. G
 online at once - an offline node that isn’t being interacted with doesn’t impact the network in any way. So a test
 cluster generated like this can be sized for the maximum size you may need, and then scaled up and down as necessary.
 
-More information can be found in network-bootstrapper.
+More information can be found in [Network Bootstrapper](../../../../../../en/platform/corda/4.8/enterprise/network-bootstrapper.md).
 
 
 


### PR DESCRIPTION
Fixed other links on page too. 