### PR TITLE
DOC-3363-3 Fix broken links in Corda OS 4.6 pages

### DIFF
--- a/content/en/platform/corda/4.6/open-source/api-scanner.md
+++ b/content/en/platform/corda/4.6/open-source/api-scanner.md
@@ -45,7 +45,7 @@ its signature somehow altered.
 * Addition of a new method to an interface or abstract class. Types that have been annotated as `@DoNotImplement` are
 excluded from this check. (This annotation is also inherited across subclasses and sub-interfaces.)
 * Exposure of an internal type via a public API. Internal types are considered to be anything in a `*.internal.` package
-or anything in a module that isn’t in the stable modules list [here](api-stability-guarantees.md#internal-apis-and-stability-guarantees).
+or anything in a module that isn’t in the stable modules list [here](api-stability-guarantees.md).
 
 Developers can execute these commands themselves before submitting their PR, to ensure that they haven’t inadvertently
 broken Corda’s API.

--- a/content/en/platform/corda/4.6/open-source/business-network-membership.md
+++ b/content/en/platform/corda/4.6/open-source/business-network-membership.md
@@ -32,7 +32,7 @@ With this extension, you can use a set of flows to:
 * Assign members to membership lists or groups.
 * Update information about a member - such as their Business Network identity.
 * Modify a member's roles in the network.
-* Suspend or revoke membership.  
+* Suspend or revoke membership.
 
 {{< note >}}
 The code samples in this documentation show you how to run management operations using the provided primitives from the context of a tool or Cordapp. It is also possible to do these operations from an RPC client or node shell by simply invoking the supplied administrative flows using data resulted from executing vault queries.
@@ -204,7 +204,7 @@ subFlow(ModifyBusinessIdentityFlow(membership.state.data.linearId, updatedIdenti
 
 ### Update a members business network roles
 
-You can update a member's business identity attributes - by modifying their roles. Depending on your proposed changes, the updated member may become an **authorised member**. In this case, your enhancement must be preceded by an execution of the [`ModifyGroupsFlow`](#modify-a-group) to add the member to all membership lists that it will have administrative powers over.
+You can update a member's business identity attributes - by modifying their roles. Depending on your proposed changes, the updated member may become an **authorised member**. In this case, your enhancement must be preceded by an execution of the <a href="#modify-a-group">`ModifyGroupsFlow`</a> to add the member to all membership lists that it will have administrative powers over.
 
 To update a member's roles and permissions in the business network:
 

--- a/content/en/platform/corda/4.6/open-source/cli-application-shell-extensions.md
+++ b/content/en/platform/corda/4.6/open-source/cli-application-shell-extensions.md
@@ -86,9 +86,9 @@ restart the shell or see [above](#installing-shell-extensions) for instructions 
 
 |Description|Alias|JAR Name|
 |---------------------------------------------------------|------------------------------|----------------------------------------------------------|
-|[Corda node](running-a-node.html#starting-an-individual-corda-node)|`corda --<option>`|`corda-4.6.jar`|
+|[Corda node](running-a-node.html#starting-a-corda-node-from-the-command-prompt)|`corda --<option>`|`corda-4.6.jar`|
 |[Network bootstrapper]({{% ref "network-bootstrapper.md" %}})|`bootstrapper --<option>`|`corda-tools-network-bootstrapper-4.6.jar`|
-|[Standalone shell](shell.html#standalone-shell)|`corda-shell --<option>`|`corda-tools-shell-cli-4.6.jar`|
+|[Standalone shell](shell.html#the-standalone-shell)|`corda-shell --<option>`|`corda-tools-shell-cli-4.6.jar`|
 |[Blob inspector]({{% ref "blob-inspector.md" %}})|`blob-inspector --<option>`|`corda-tools-blob-inspector-4.6.jar`|
 
 {{< /table >}}

--- a/content/en/platform/corda/4.6/open-source/cli-ux-guidelines.md
+++ b/content/en/platform/corda/4.6/open-source/cli-ux-guidelines.md
@@ -96,7 +96,7 @@ A `-v` short option should also be provided.
 ### Parameter stability
 
 
-* keep both versions of the parameter. See [Backwards Compatibility](#cli-ux-backwards-compatibility) for more information.
+* keep both versions of the parameter. See [Backwards Compatibility](#backwards-compatibility) for more information.
 
 
 ## Notes for adding a new a command line application

--- a/content/en/platform/corda/4.6/open-source/contributing-flow-state-machines.md
+++ b/content/en/platform/corda/4.6/open-source/contributing-flow-state-machines.md
@@ -32,7 +32,7 @@ To add a suspending operation for a simple request-response type function that p
 use `FlowExternalOperation` or `FlowExternalAsyncOperation`. These interfaces represent the public versions of the internal
 `FlowAsyncOperation`.
 
-See [calling external systems inside of flows](api-flows.md#api-flows-external-operations) for more information on these public interfaces.
+See [calling external systems inside of flows](api-flows.html#flowexternaloperation) for more information on these public interfaces.
 
 
 ## How to test

--- a/content/en/platform/corda/4.6/open-source/contributing.md
+++ b/content/en/platform/corda/4.6/open-source/contributing.md
@@ -24,12 +24,12 @@ There are several ways to identify an area where you can contribute to Corda:
 
 
 * If you'd like to contribute, but don't have a specific project in mind:
-    * Message a [Community Maintainer](contributing-philosophy.md#community-maintainers) saying “I want to help!”. They’ll work
+    * Message a [Community Maintainer](contributing-philosophy.html#community-maintainers) saying “I want to help!”. They’ll work
 with you to find an area for you to contribute.
     * Browse the issues labelled `help wanted` on the
 [Corda GitHub issues](https://github.com/corda/corda/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) page. Issues labeled `good first issue` are ideal for first-timers.
 * If you have a specific contribution in mind, message the
-`#contributing` channel of the [Corda Slack](http://cordaledger.slack.com/) or contact one of the [Community Maintainers](contributing-philosophy.md#community-maintainers) directly to confirm if it is appropriate before starting development.
+`#contributing` channel of the [Corda Slack](http://cordaledger.slack.com/) or contact one of the [Community Maintainers](contributing-philosophy.html#community-maintainers) directly to confirm if it is appropriate before starting development.
 
 
 
@@ -44,9 +44,9 @@ One of the things that makes Corda special is its coherent design. That's why we
 * **Scope**: To ensure the Corda project remains coherent and focused, so we ask that the feature’s scope is within the definition specified in the [Corda Technical Whitepaper](/en/pdf/corda-technical-whitepaper.pdf).
 * **Maintainability**: If the feature requires ongoing maintenance (for example, support for a particular brand of database), we may ask you to accept responsibility for maintaining it.
 * **Non-duplicative**: If the contribution duplicates features that already exist or are in progress, you may be asked to work with the project maintainers to reconcile this. As the major contributor to Corda, many employees of [R3](https://r3.com) are working on features at any given time. To avoid surprises and foster transparency,
-[our Jira work tracking system is public](https://r3-cev.atlassian.net/projects/CORDA/summary). If in doubt, reach out to one of the [Community Maintainers](contributing-philosophy.md#community-maintainers).
+[our Jira work tracking system is public](https://r3-cev.atlassian.net/projects/CORDA/summary). If in doubt, reach out to one of the [Community Maintainers](contributing-philosophy.html#community-maintainers).
 
-In addition, there are a number of additional requirements that apply to ["large" contributions](contributing.md#large-contributions).
+In addition, there are a number of additional requirements that apply to [large contributions](contributing.html#large-contributions).
 
 ## Making changes to Corda
 
@@ -118,7 +118,7 @@ Document any changes to Corda’s public API:
 with a full stop. We also start comments with capital letters, even for inline comments. Where Java APIs have
 synonyms (e.g. `%d` and `%date`), we prefer the longer form for legibility reasons. You can configure your IDE to highlight these in yellow.
 2. Update the relevant .rst file(s).
-3. Include the change in the [changelog](changelog.md) if the change is external and therefore visible to CorDapp
+3. Include the change in the [changelog](../../../../../en/platform/corda/4.6/open-source/release-notes.md) if the change is external and therefore visible to CorDapp
 developers and/or node operators.
 4. [Build the docs locally](building-the-docs.md) and check that the resulting .html files (under `docs/build/html`) for the modified
 render correctly.
@@ -131,7 +131,7 @@ If you add a new API or feature and don’t update the samples, your work will h
 1. Create a pull request (PR) from your fork to the equivalent branch of the Corda repo.
 
 2. Complete the PR checklist in the **comments box**.
-    * Have you run [unit, integration and smoke tests](https://docs.corda.net/head/testing.html)?
+    * Have you run [unit, integration and smoke tests](../../../../../en/platform/corda/4.6/open-source/testing.md)?
     * If you added/changed public APIs, did you write/update the JavaDocs?
     * If the changes are of interest to application developers, have you added them to the changelog and release notes where applicable?
     * If you are contributing for the first time, please read the contribution guidelines above and indicate your agreement.
@@ -141,7 +141,7 @@ If you add a new API or feature and don’t update the samples, your work will h
 accordance with the Developer Certificate of Origin ([https://developercertificate.org/](https://developercertificate.org/)).”
 
 5. Request a review by reaching out in the `#contributing` channel of the [Corda Slack](http://cordaledger.slack.com/) or contacting one of
-the [Community Maintainers](contributing-philosophy.md#community-maintainers) directly. The reviewer will either:
+the [Community Maintainers](contributing-philosophy.html#community-maintainers) directly. The reviewer will either:
     * Accept and merge your PR
     * Leave comments requesting changes via the GitHub PR interface
 
@@ -181,7 +181,7 @@ The process for contributing a large change to Corda is as follows:
 
 3. If the proposal is accepted, please raise a design PR on the [Corda GitHub project](https://github.com/corda/corda). The design should give the rationale for the change, how the change will be implemented, and what alternative designs were rejected. The engineering team will review your design and indicate any required changes.
 
-4. Once the design is approved, please go ahead with the change according to the [guidelines for small and medium contributions](contributing.md#making-the-required-changes). In addition to those guidelines, we require that large contributions be fully exercised by tests, including any exception paths and error handling.
+4. Once the design is approved, please go ahead with the change according to the [guidelines for small and medium contributions](contributing.html#making-changes-to-corda). In addition to those guidelines, we require that large contributions be fully exercised by tests, including any exception paths and error handling.
 
 
 ## Developer Certificate of Origin

--- a/content/en/platform/corda/4.6/open-source/docker-image.md
+++ b/content/en/platform/corda/4.6/open-source/docker-image.md
@@ -97,7 +97,7 @@ It is possible to utilize the image to automatically generate a sensible minimal
 Requirements: A Compatibility Zone, the Zone Trust Root and authorisation to join said Zone.
 
 {{< /note >}}
-It is possible to use the image to automate the process of joining an existing Zone as detailed [here](joining-a-compatibility-zone.html#connecting-to-a-compatibility-zone)
+It is possible to use the image to automate the process of joining an existing Zone as detailed [here](joining-a-compatibility-zone.md)
 
 The first step is to obtain the Zone Trust Root, and place it within a directory. In the below example, the Trust Root is stored at `/home/user/docker/certificates/network-root-truststore.jks`.
 It is possible to configure the name of the Trust Root file by setting the `TRUST_STORE_NAME` environment variable in the container.

--- a/content/en/platform/corda/4.6/open-source/network-map.md
+++ b/content/en/platform/corda/4.6/open-source/network-map.md
@@ -65,7 +65,7 @@ Note that only HTTP OK (response code 200) is supported - any other kind of resp
 ### Additional endpoints from R3
 
 Network maps hosted by R3 or other parties using R3’s commercial network management tools typically provide some
-additional endpoints for users. These additional endpoints can be found [here](../../cenm/1.4/network-map-overview.md).
+additional endpoints for users. These additional endpoints can be found [here](../../../../../en/platform/corda/1.4/cenm/network-map-overview.md).
 
 HTTP is used for the network map service instead of Corda’s own AMQP based peer to peer messaging protocol to
 enable the server to be placed behind caching content delivery networks like Cloudflare, Akamai, Amazon Cloudfront and so on.

--- a/content/en/platform/corda/4.6/open-source/running-a-notary.md
+++ b/content/en/platform/corda/4.6/open-source/running-a-notary.md
@@ -42,7 +42,7 @@ For a validating notary service specify:
 notary : { validating : true }
 ```
 
-See [Validation](key-concepts-notaries.md#key-concepts-notaries-validation) for more details about validating versus non-validating notaries.
+See [Validation](key-concepts-notaries.html#validation) for more details about validating versus non-validating notaries.
 
 For clients to be able to use the notary service, its identity must be added to the network parameters. This will be
 done automatically when creating the network, if using [Network Bootstrapper](network-bootstrapper.md). See [Networks](corda-networks-index.md)

--- a/content/en/platform/corda/4.6/open-source/setting-up-a-dynamic-compatibility-zone.md
+++ b/content/en/platform/corda/4.6/open-source/setting-up-a-dynamic-compatibility-zone.md
@@ -96,7 +96,7 @@ You can use an existing network map implementation such as the
 
 #### Writing a network map server
 
-This server implements a simple HTTP based protocol described in the “[The network map](network-map.md)” page.
+This server implements a simple HTTP based protocol described in [The network map](network-map.md).
 The map server is responsible for gathering NodeInfo files from nodes, storing them, and distributing them back to the
 nodes in the zone. By doing this it is also responsible for choosing who is in and who is out: having a signed
 identity certificate is not enough to be a part of a Corda zone, you also need to be listed in the network map.
@@ -193,7 +193,7 @@ signedParams.open().copyTo(Paths.get("/some/path"))
 
 {{< /tabs >}}
 
-Each individual parameter is documented in [the JavaDocs/KDocs for the NetworkParameters class](https://docs.corda.net/api/kotlin/corda/net.corda.core.node/-network-parameters/index.html). The network map
+Each individual parameter is documented in [the JavaDocs/KDocs for the NetworkParameters class](https://docs.r3.com/en/api-ref/corda/4.6/open-source/kotlin/corda/net.corda.core.node/-network-parameters/index.html). The network map
 certificate is usually chained off the root certificate, and can be created according to the instructions above. Each
 time the zone parameters are changed, the epoch should be incremented. Epochs are essentially version numbers for the
 parameters, and they therefore cannot go backwards. Once saved, the new parameters can be served by the network map server.

--- a/content/en/platform/corda/4.6/open-source/testing.md
+++ b/content/en/platform/corda/4.6/open-source/testing.md
@@ -64,7 +64,7 @@ program starts, that you can interact with it, and that no exceptions are genera
 ## Running tests in IntelliJ
 
 We recommend editing your IntelliJ preferences so that you use the Gradle runner - this means that the quasar utils
-plugin will make sure that some flags (like `-javaagent` - see [below](#tutorial-cordapp-alternative-test-runners)) are
+plugin will make sure that some flags (like `-javaagent`) are
 set for you.
 
 To switch to using the Gradle runner:


### PR DESCRIPTION
Covers sections (header pages and child pages):

- Operations:
--> Networks
--> Official Corda Docker Image
--> Load testing
--> Shell extensions for CLI Applications

- Corda Network Foundations
- Participate