### PR TITLE
DOC-3564: Text wrapping incorrectly in version number tables

### DIFF
--- a/content/en/platform/corda/4.3/enterprise/platform-support-matrix.md
+++ b/content/en/platform/corda/4.3/enterprise/platform-support-matrix.md
@@ -119,8 +119,7 @@ Driver 8.0.16|
 
 |Vendor|CPU Architecture|Versions|JDBC Driver|
 |-------------------------------|------------------|------------------|--------------------|
-|CockroachDB|x86-64|19.1.2|PostgreSQL JDBC
-Driver 42.1.4|
+|CockroachDB|x86-64|19.1.2|PostgreSQL JDBC Driver 42.1.4|
 |Oracle RAC|x86-64|12cR2|Oracle JDBC 8|
 
 {{< /table >}}


### PR DESCRIPTION
Quick bug fix - text was wrapping incorrectly in version number tables of the platform support matrix in Corda Enterprise 4.3.