### PR TITLE
NOTICK: remove Hugo warning about `.File.Dir`

### DIFF
--- a/themes/doks/layouts/partials/sidebar/versions.html
+++ b/themes/doks/layouts/partials/sidebar/versions.html
@@ -23,10 +23,9 @@
 {{ end }}
 {{ end }}
 
-{{$currentUrl := .RelPermalink}}
-{{ $currentPath := path.Dir .File.Dir }}
-
 {{ if and (ne $currentVersion "Versions") (gt $totalVersions 1)}}
+  {{ $currentUrl := .RelPermalink }}
+  {{ $currentPath := path.Dir .File.Dir }}
   {{/* We know whether we're in 'corda-os-4.4' or not ('Versions') */}}
 
   <li class="nav-item dropdown">


### PR DESCRIPTION
> .File.Dir on zero object.
> Wrap it in if or with: {{ with .File }}{{ .Dir }}{{ end }}

This is caused when moved lines where evaluated for 404.html and main
index.html page, when there was no context to work with.

This is a cosmetic change, however it was a misleading one when I was
looking for a root reason of a completely different issue.