### PR TITLE
EG-4795 Providing better comamnd-line guidance on AzureAD vs internal auth

### DIFF
--- a/content/en/platform/corda/4.7/enterprise/node/auth-service.md
+++ b/content/en/platform/corda/4.7/enterprise/node/auth-service.md
@@ -209,12 +209,16 @@ Command line arguments:
 * `[--seed]` Optional seed for config deobfuscation.
 * `[-v, --verbose]` Redirect all log output to the console. Also sets logging level to INFO.
 * `[--logging-level]` Sets logging level. Accepts Log4j Levels.
+* `[--initial-user-provider]` Sets the authentication provider for the initial user. Valid values are ```internal``` or ```azuread```; the default is ```internal```.
 
-Initial user **initializer**: This command group allows configuration of the initial admin user. Both options are required when any of them is in use.
+Initial user **initializer**: This command group allows configuration of the initial admin user.
+
 * `[--initial-user-name]` Sets the name of the user.
-* `[--initial-user-password]` Sets the password of the user.
+* `[--initial-user-password]` Sets the password of the user when provider is ```internal```.
+* `[--initial-user-external-id]` External id of the user when using a provider other than ```internal``` that requires it. In case of AzureAD this should be the ObjectID of the user whose username is used in the ```--initial-user-name``` parameter.
 
-* `[--restore-admin-capability]` ()**initializer**) If all admin users are locked out, for example because of password policy, this option unlocks them.
+
+* `[--restore-admin-capability]` (**initializer**) If all admin users are locked out, for example because of password policy, this option unlocks them.
 
 Reset user (**initializer**): Use this command group to reset, re-enable, and unlock a user. You can also sets a user's password or force the user to become an administrator. Administrators can create and edit other users, but cannot access CENM services directly.
 

--- a/content/en/platform/corda/4.7/enterprise/node/auth-service.md
+++ b/content/en/platform/corda/4.7/enterprise/node/auth-service.md
@@ -215,7 +215,7 @@ Initial user **initializer**: This command group allows configuration of the ini
 
 * `[--initial-user-name]` Sets the name of the user.
 * `[--initial-user-password]` Sets the password of the user when provider is ```internal```.
-* `[--initial-user-external-id]` External id of the user when using a provider other than ```internal``` that requires it. In case of AzureAD this should be the ObjectID of the user whose username is used in the ```--initial-user-name``` parameter.
+* `[--initial-user-external-id]` External ID of the user when using a provider other than ```internal``` that requires it. In case of AzureAD this should be the ObjectID of the user whose user name is used in the ```--initial-user-name``` parameter.
 
 
 * `[--restore-admin-capability]` (**initializer**) If all admin users are locked out, for example because of password policy, this option unlocks them.

--- a/content/en/platform/corda/4.8/enterprise/node/auth-service.md
+++ b/content/en/platform/corda/4.8/enterprise/node/auth-service.md
@@ -210,12 +210,16 @@ Command line arguments:
 * `[--seed]` Optional seed for config deobfuscation.
 * `[-v, --verbose]` Redirect all log output to the console. Also sets logging level to INFO.
 * `[--logging-level]` Sets logging level. Accepts Log4j Levels.
+* `[--initial-user-provider]` Sets the authentication provider for the initial user. Valid values are ```internal``` or ```azuread```; the default is ```internal```.
 
-Initial user **initializer**: This command group allows configuration of the initial admin user. Both options are required when any of them is in use.
+Initial user **initializer**: This command group allows configuration of the initial admin user.
+
 * `[--initial-user-name]` Sets the name of the user.
-* `[--initial-user-password]` Sets the password of the user.
+* `[--initial-user-password]` Sets the password of the user when provider is ```internal```.
+* `[--initial-user-external-id]` External id of the user when using a provider other than ```internal``` that requires it. In case of AzureAD this should be the ObjectID of the user whose username is used in the ```--initial-user-name``` parameter.
 
-* `[--restore-admin-capability]` ()**initializer**) If all admin users are locked out, for example because of password policy, this option unlocks them.
+
+* `[--restore-admin-capability]` (**initializer**) If all admin users are locked out, for example because of password policy, this option unlocks them.
 
 Reset user (**initializer**): Use this command group to reset, re-enable, and unlock a user. You can also sets a user's password or force the user to become an administrator. Administrators can create and edit other users, but cannot access CENM services directly.
 

--- a/content/en/platform/corda/4.8/enterprise/node/auth-service.md
+++ b/content/en/platform/corda/4.8/enterprise/node/auth-service.md
@@ -216,7 +216,7 @@ Initial user **initializer**: This command group allows configuration of the ini
 
 * `[--initial-user-name]` Sets the name of the user.
 * `[--initial-user-password]` Sets the password of the user when provider is ```internal```.
-* `[--initial-user-external-id]` External id of the user when using a provider other than ```internal``` that requires it. In case of AzureAD this should be the ObjectID of the user whose username is used in the ```--initial-user-name``` parameter.
+* `[--initial-user-external-id]` External ID of the user when using a provider other than ```internal``` that requires it. In case of AzureAD this should be the ObjectID of the user whose user name is used in the ```--initial-user-name``` parameter.
 
 
 * `[--restore-admin-capability]` (**initializer**) If all admin users are locked out, for example because of password policy, this option unlocks them.


### PR DESCRIPTION
A user had trouble logging in to AzureAD; the solution was to use the ObjectID as initial-user-external-id, but this was not well-documented. Updated the README.md to provide clarity. There is a matching patch going into appeng-auth repo (but this one can be deployed independently; the functionality already exists).