### PR TITLE
DOC-3710-1: Quick links to 4.x docs from landing page

### DIFF
--- a/themes/doks/layouts/index.html
+++ b/themes/doks/layouts/index.html
@@ -165,8 +165,8 @@
             <h3 class="card-title">Corda 4</h3>
             <p>Everything you need to know about the Corda 4 platform series - read the comprehensive documentation sets for:</p>
             <ul>
-              <li style="text-align: left;"><a href="en/platform/corda/4.8/open-source.html">Corda OS 4.8</a></li>
               <li style="text-align: left;"><a href="en/platform/corda/4.8/enterprise.html">Corda Enterprise 4.8</a></li>
+              <li style="text-align: left;"><a href="en/platform/corda/4.8/open-source.html">Corda OS 4.8</a></li>
               <li style="text-align: left;"><a href="en/platform/corda/1.5/cenm.html">CENM 1.5</a></li>
             </ul>
           </div>

--- a/themes/doks/layouts/index.html
+++ b/themes/doks/layouts/index.html
@@ -173,12 +173,13 @@
       <div class="col">
         <div class="card no-border h-100">
           <div class="card-body">
-            <h3 class="card-title">API reference</h3>
-            <p>Find complete documentation reference in Javadoc and KDoc format for all publicly exposed APIs in the Corda 5 Developer Preview and the Corda 4
-             series (Corda open source 4.x, Corda Enterprise 4.x, and Corda Enterprise Network Manager 1.x).</p>
-          </div>
-          <div class="card-footer">
-            <a href="en/api-ref.html" class="btn rounded external">View API references</a>
+            <h3 class="card-title">Corda 4</h3>
+            <p>Everything you need to know about the Corda 4 platform series - read the comprehensive documentation sets for:</p>
+            <ul>
+              <li style="text-align: left;"><a href="en/platform/corda/4.8/open-source.html">Corda OS 4.8</a></li>
+              <li style="text-align: left;"><a href="en/platform/corda/4.8/enterprise.html">Corda Enterprise 4.8</a></li>
+              <li style="text-align: left;"><a href="en/platform/corda/1.5/cenm.html">CENM 1.5</a></li>
+            </ul>
           </div>
         </div>
       </div>

--- a/themes/doks/layouts/index.html
+++ b/themes/doks/layouts/index.html
@@ -176,7 +176,8 @@
         <div class="card no-border h-100">
           <div class="card-body">
             <h3 class="card-title">API reference</h3>
-            <p>Find complete documentation reference in Javadoc and KDoc format for all publicly exposed APIs in the Corda 5 Developer Preview and the Corda 4 series (Corda open source 4.x, Corda Enterprise 4.x, and Corda Enterprise Network Manager 1.x).</p>
+            <p>Find complete documentation reference in Javadoc and KDoc format for all publicly exposed APIs in the Corda 5 Developer Preview and the Corda 4
+              series (Corda open source 4.x, Corda Enterprise 4.x, and Corda Enterprise Network Manager 1.x).</p>
           </div>
           <div class="card-footer">
             <a href="en/api-ref.html" class="btn rounded external">View API references</a>

--- a/themes/doks/layouts/index.html
+++ b/themes/doks/layouts/index.html
@@ -177,7 +177,7 @@
           <div class="card-body">
             <h3 class="card-title">API reference</h3>
             <p>Find complete documentation reference in Javadoc and KDoc format for all publicly exposed APIs in the Corda 5 Developer Preview and the Corda 4
-              series (Corda open source 4.x, Corda Enterprise 4.x, and Corda Enterprise Network Manager 1.x).</p>
+             series (Corda open source 4.x, Corda Enterprise 4.x, and Corda Enterprise Network Manager 1.x).</p>
           </div>
           <div class="card-footer">
             <a href="en/api-ref.html" class="btn rounded external">View API references</a>

--- a/themes/doks/layouts/index.html
+++ b/themes/doks/layouts/index.html
@@ -183,6 +183,9 @@
           </div>
         </div>
       </div>
+      <div class="card-footer">
+        <a href="en/api-ref.html" class="btn rounded external">View API references</a>
+      </div>
       <div class="col">
         <div class="card no-border h-100">
           <div class="card-body">

--- a/themes/doks/layouts/index.html
+++ b/themes/doks/layouts/index.html
@@ -176,8 +176,7 @@
         <div class="card no-border h-100">
           <div class="card-body">
             <h3 class="card-title">API reference</h3>
-            <p>Find complete documentation reference in Javadoc and KDoc format for all publicly exposed APIs in the Corda 5 Developer Preview and the Corda 4
-              series (Corda open source 4.x, Corda Enterprise 4.x, and Corda Enterprise Network Manager 1.x).</p>
+            <p>Find complete documentation reference in Javadoc and KDoc format for all publicly exposed APIs in the Corda 5 Developer Preview and the Corda 4 series (Corda open source 4.x, Corda Enterprise 4.x, and Corda Enterprise Network Manager 1.x).</p>
           </div>
           <div class="card-footer">
             <a href="en/api-ref.html" class="btn rounded external">View API references</a>

--- a/themes/doks/layouts/index.html
+++ b/themes/doks/layouts/index.html
@@ -163,17 +163,6 @@
         <div class="card no-border h-100">
           <div class="card-body">
             <h3 class="card-title">Corda 4</h3>
-            <p>Everything you need to know about the Corda 4 platform series - read the comprehensive documentation sets for Corda open source 4.x, Corda Enterprise 4.x, and Corda Enterprise Network Manager 1.x.</p>
-          </div>
-          <div class="card-footer">
-            <a href="en/platform/corda/4.8/open-source.html" class="btn rounded">Ready, set, read!</a>
-          </div>
-        </div>
-      </div>
-      <div class="col">
-        <div class="card no-border h-100">
-          <div class="card-body">
-            <h3 class="card-title">Corda 4</h3>
             <p>Everything you need to know about the Corda 4 platform series - read the comprehensive documentation sets for:</p>
             <ul>
               <li style="text-align: left;"><a href="en/platform/corda/4.8/open-source.html">Corda OS 4.8</a></li>
@@ -183,8 +172,17 @@
           </div>
         </div>
       </div>
-      <div class="card-footer">
-        <a href="en/api-ref.html" class="btn rounded external">View API references</a>
+      <div class="col">
+        <div class="card no-border h-100">
+          <div class="card-body">
+            <h3 class="card-title">API reference</h3>
+            <p>Find complete documentation reference in Javadoc and KDoc format for all publicly exposed APIs in the Corda 5 Developer Preview and the Corda 4
+              series (Corda open source 4.x, Corda Enterprise 4.x, and Corda Enterprise Network Manager 1.x).</p>
+          </div>
+          <div class="card-footer">
+            <a href="en/api-ref.html" class="btn rounded external">View API references</a>
+          </div>
+        </div>
       </div>
       <div class="col">
         <div class="card no-border h-100">


### PR DESCRIPTION
The Corda 4 box now links directly to latest versions of OS, Enterprise, and CENM. Will need to be updated with releases.