### PR TITLE
DOC-3762: Add link to gradle plugin page from tutorials pages

### DIFF
--- a/content/en/platform/corda/5.0-dev-preview-1/tutorials/building-cordapp/c5-basic-cordapp-running.md
+++ b/content/en/platform/corda/5.0-dev-preview-1/tutorials/building-cordapp/c5-basic-cordapp-running.md
@@ -31,7 +31,7 @@ Before you run your Mission Mars CorDapp, you may want to compare your files to 
 
 ## Deploy your CorDapp to a local Corda 5 network
 
-1. Compile the CorDapp's code into the Corda package files (`.cpk`s) by running the `./gradlew clean build` command from the root of your project.
+1. Compile the CorDapp's code into the Corda package files (`.cpk`s) by running the `./gradlew clean build` command from the root of your project. See the [Gradle plugin page](../../../../../../en/platform/corda/5.0-dev-preview-1/packaging/gradle-plugin/overview.md) for more information about using this plugin.
 
 2. Assemble your `.cpk` files into a single Corda package bundle (`.cpb`) file using the CorDapp Builder CLI:
 

--- a/content/en/platform/corda/5.0-dev-preview-1/tutorials/run-demo-cordapp.md
+++ b/content/en/platform/corda/5.0-dev-preview-1/tutorials/run-demo-cordapp.md
@@ -43,6 +43,7 @@ Before you run the sample CorDapp:
     * The [Corda CLI](../../../../../en/platform/corda/5.0-dev-preview-1/corda-cli/overview.md).
     * The [CorDapp Builder](../../../../../en/platform/corda/5.0-dev-preview-1/packaging/cordapp-builder.md).
     * The [Corda Node CLI](../../../../../en/platform/corda/5.0-dev-preview-1/nodes/operating/cli-curl/cli-curl.md).
+    * The [CorDapp CPK and CPB Gradle plugins](../../../../../en/platform/corda/5.0-dev-preview-1/packaging/gradle-plugin/overview.md)
 
 If you're new to Corda, check out the [CorDapp documentation](../../../../../en/platform/corda/5.0-dev-preview-1/cordapps/overview.md) for key concepts.
 


### PR DESCRIPTION
We had a request on Slack to link to the Gradle plugins page from the tutorials. This will help the user see their options for packaging their CorDapp. They can use the Gradle plugin rather than using the CorDapp builder if it's more convenient. This should be linked in the sections where the user is instructed to use the CorDapp Builder and given as an alternative.