### PR TITLE
DOC-3865: Completing instructions on adding class to serialization whitelist

### DIFF
--- a/content/en/platform/corda/4.8/enterprise/operations/deployment/host-prereq.md
+++ b/content/en/platform/corda/4.8/enterprise/operations/deployment/host-prereq.md
@@ -54,7 +54,7 @@ weight: 2
 |Microsoft|x86-64|Azure SQL,SQL Server 2017|Microsoft JDBC Driver 6.4|
 |Oracle|x86-64|11gR2|Oracle JDBC 6|
 |Oracle|x86-64|12cR2|Oracle JDBC 8|
-|PostgreSQL|x86-64|9.6, 10.10, 11.5|PostgreSQL JDBC Driver 42.1.4 / 42.2.8|
+|PostgreSQL|x86-64|9.6, 10.10, 11.5, 13.3|PostgreSQL JDBC Driver 42.1.4 / 42.2.8|
 
 
 {{< /table >}}

--- a/content/en/platform/corda/4.8/enterprise/serialization.md
+++ b/content/en/platform/corda/4.8/enterprise/serialization.md
@@ -54,11 +54,11 @@ To add a class to the whitelist, you must either:
 class itself, on any super-class of the class, on any interface implemented by the class or its super-classes, or on any
 interface extended by an interface implemented by the class or its super-classes. This is the preferred method.
 * Implement the `SerializationWhitelist` interface and specify a list of whitelisted classes.
-* It is also possible to whitelist types for serialization using the [java.util.ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) mechanism. The name of the class must appear in a text file on the classpath under the path:
+  * Provide a subclass of this using the [java.util.ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) mechanism. The name of the class must appear in a text file on the classpath under the path:
 
-    ```
-    META-INF/services/net.corda.core.serialization.SerializationWhitelist
-    ```
+      ```
+      META-INF/services/net.corda.core.serialization.SerializationWhitelist
+      ```
 
 The built-in default whitelist (see the `DefaultWhitelist` class) allows common JDK classes for
 convenience. You cannot edit the default whitelist.

--- a/content/en/platform/corda/4.8/enterprise/serialization.md
+++ b/content/en/platform/corda/4.8/enterprise/serialization.md
@@ -54,7 +54,7 @@ To add a class to the whitelist, you must either:
 class itself, on any super-class of the class, on any interface implemented by the class or its super-classes, or on any
 interface extended by an interface implemented by the class or its super-classes. This is the preferred method.
 * Implement the `SerializationWhitelist` interface and specify a list of whitelisted classes.
-  * Provide a subclass of this using the [java.util.ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) mechanism. The name of the class must appear in a text file on the classpath under the path:
+  * Use the [java.util.ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) mechanism to add a subclass to this. The name of the class must appear in a text file on the classpath under the path:
 
       ```
       META-INF/services/net.corda.core.serialization.SerializationWhitelist

--- a/content/en/platform/corda/4.8/enterprise/serialization.md
+++ b/content/en/platform/corda/4.8/enterprise/serialization.md
@@ -54,7 +54,7 @@ To add a class to the whitelist, you must either:
 class itself, on any super-class of the class, on any interface implemented by the class or its super-classes, or on any
 interface extended by an interface implemented by the class or its super-classes. This is the preferred method.
 * Implement the `SerializationWhitelist` interface and specify a list of whitelisted classes.
-  * Use the [java.util.ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) mechanism to add a subclass to this. The name of the class must appear in a text file on the classpath under the path:
+  * Use the [java.util.ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) mechanism to add a subclass to the `SerializationWhitelist`. The name of the class must appear in a text file on the classpath under the path:
 
       ```
       META-INF/services/net.corda.core.serialization.SerializationWhitelist

--- a/content/en/platform/corda/4.8/enterprise/serialization.md
+++ b/content/en/platform/corda/4.8/enterprise/serialization.md
@@ -15,7 +15,6 @@ weight: 1
 # Object serialization
 
 
-
 Serialization converts objects into a stream of bytes. Deserialization, the reverse
 process, creates objects from a stream of bytes. These two processes take place every time nodes pass objects to each other as
 messages, when the node sends objects to or from RPC clients, and when you store transactions in the database.
@@ -51,11 +50,15 @@ is on a whitelist of allowed classes.
 
 To add a class to the whitelist, you must either:
 
-
 * Add the `@CordaSerializable` annotation to the class. This annotation can be present on the
 class itself, on any super-class of the class, on any interface implemented by the class or its super-classes, or on any
 interface extended by an interface implemented by the class or its super-classes. This is the preferred method.
 * Implement the `SerializationWhitelist` interface and specify a list of whitelisted classes.
+* It is also possible to whitelist types for serialization using the [java.util.ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) mechanism. The name of the class must appear in a text file on the classpath under the path:
+
+    ```
+    META-INF/services/net.corda.core.serialization.SerializationWhitelist
+    ```
 
 The built-in default whitelist (see the `DefaultWhitelist` class) allows common JDK classes for
 convenience. You cannot edit the default whitelist.


### PR DESCRIPTION
From the ticket:

"Turns out this is missing one critical step, which can be found only in Corda code itself. Without this critical step it does not work.

"/**

Provide a subclass of this via the [java.util.ServiceLoader] mechanism to be able to whitelist types for

serialisation that you cannot otherwise annotate. The name of the class must appear in a text file on the

classpath under the path META-INF/services/net.corda.core.serialization.SerializationWhitelist
 */""


