### PR TITLE
ENT-6490: Update Node Docker instruction for OS 4.9

### DIFF
--- a/content/en/platform/corda/4.9/community/node-docker-deployments.md
+++ b/content/en/platform/corda/4.9/community/node-docker-deployments.md
@@ -138,7 +138,7 @@ There are some optional variables which allow customisation of the generated con
 * `MY_P2P_PORT` - The port to advertise the node on (defaults to 10200). If changed, ensure the container is launched with the correct published ports.
 * `MY_RPC_PORT` - The port to open for RPC connections to the node (defaults to 10201). If changed, ensure the container is launched with the correct published ports.
 
-Once the container has finished performing the initial registration, it should be possible to initialize node's DB
+Once the container has finished performing the initial registration, it is necessary to initialize node's DB
 as follows:
 
 ```shell

--- a/content/en/platform/corda/4.9/community/node-docker-deployments.md
+++ b/content/en/platform/corda/4.9/community/node-docker-deployments.md
@@ -145,6 +145,7 @@ as follows:
 docker run -ti \
         --memory=2048m \
         --cpus=2 \
+        -e CORDA_ARGS="run-migration-scripts --core-schemas --app-schemas"      \
         -v /home/user/docker/config:/etc/corda \
         -v /home/user/docker/certificates:/opt/corda/certificates \
         -v /home/user/docker/persistence:/opt/corda/persistence \
@@ -152,7 +153,7 @@ docker run -ti \
         -v /home/user/corda/samples/bank-of-corda-demo/build/nodes/BankOfCorda/cordapps:/opt/corda/cordapps \
         -p 10200:10200 \
         -p 10201:10201 \
-        corda/corda-zulu-java1.8-4.9:latest run-migration-scripts --core-schemas --app-schemas
+        corda/corda-zulu-java1.8-4.9:latest
 ```
 
 After that the node can be started as normal:


### PR DESCRIPTION
Changing instructions for OS 4.9.
Once this is reviewed by @corda/technical-writers then this change should be reflected on versions of Corda OS from 4.6 onwards.