### PR TITLE
DOC-3988: added cress-ref for standalone shell from Release Notes

### DIFF
--- a/content/en/platform/corda/4.9/community/release-notes.md
+++ b/content/en/platform/corda/4.9/community/release-notes.md
@@ -55,7 +55,7 @@ For more information about platform versions, see [Versioning](../../../../../en
 
 Issues fixed in Corda Community 4.9:
 
-* Corda Shell has been removed to its own repository for improved security. You can now use a standalone shell outside of the node, or from within the node's drivers.  You can read more about using the standalone shell [here](shell.md#the-standalone-shell).
+* Corda Shell has been removed to its own repository for improved security. You can now use a standalone shell outside of the node, or from within the node's drivers.  You can read more about using the standalone shell [here](shell.html#the-standalone-shell).
 * Security updates to prevent possibility of Denial of Service attacks.
 * Improvements to demos and sample code.
 * Improvements to improve compatibility with Intel Macs.

--- a/content/en/platform/corda/4.9/community/release-notes.md
+++ b/content/en/platform/corda/4.9/community/release-notes.md
@@ -26,7 +26,7 @@ In this patch release:
 
 * Fixing of a bug where `SuspensionMeta` in `FlowInfo` shows as null even when a runnable flow has previously been hospitalized.
 * Update Hibernate version to a more secure version that matches Corda Enterprise.
-* Oracle JDK version 8u322 now supported. 
+* Oracle JDK version 8u322 now supported.
 ## Corda Community Edition 4.9
 
 **Corda Community Edition** is here. This edition of Corda gives you the freedom of Corda's Open Source platform, with the benefits of [affordable support](https://r3.com/support). All the same fundamentals of Corda 4.8 are included, along with security updates, newly available APIs and sample code improvements. You can upgrade your existing Corda projects to Community Edition any time to be eligible for our support packages.
@@ -55,7 +55,7 @@ For more information about platform versions, see [Versioning](../../../../../en
 
 Issues fixed in Corda Community 4.9:
 
-* Corda Shell has been removed to its own repository for improved security. You can now use a standalone shell outside of the node, or from within the node's drivers.
+* Corda Shell has been removed to its own repository for improved security. You can now use a standalone shell outside of the node, or from within the node's drivers.  You can read more about using the standalone shell [here](shell.md#the-standalone-shell).
 * Security updates to prevent possibility of Denial of Service attacks.
 * Improvements to demos and sample code.
 * Improvements to improve compatibility with Intel Macs.

--- a/content/en/platform/corda/4.9/enterprise/release-notes-enterprise.md
+++ b/content/en/platform/corda/4.9/enterprise/release-notes-enterprise.md
@@ -51,7 +51,7 @@ As a node operator, you should upgrade to the [latest released version of Corda]
 
 In this release:
 
-* Corda Shell has been removed to its own repository for improved security. You can now use a standalone shell outside of the node, or from within the node's drivers. You can read more about using the standalone shell [here](/node/operating/shell.html#the-standalone-shell).
+* Corda Shell has been removed to its own repository for improved security. You can now use a standalone shell outside of the node, or from within the node's drivers. You can read more about using the standalone shell [here](./node/operating/shell.html#the-standalone-shell).
 * Security updates to prevent possibility of Denial of Service attacks.
 * Improvements to demos and sample code.
 * Improvements to improve compatibility with Intel Macs.

--- a/content/en/platform/corda/4.9/enterprise/release-notes-enterprise.md
+++ b/content/en/platform/corda/4.9/enterprise/release-notes-enterprise.md
@@ -33,7 +33,7 @@ In this patch release:
 
 * Fixing of a bug where `SuspensionMeta` in `FlowInfo` shows as null even when a runnable flow has previously been hospitalized.
 * Official Artemis binaries implemented.
-* Oracle JDK version 8u322 now supported. 
+* Oracle JDK version 8u322 now supported.
 ## Corda: Enterprise Edition 4.9
 
 Corda: Enterprise Edition  4.9 features many security improvements, along with a stand alone Shell for controlling the node via command line. You can also now access the `flowrpcops` API
@@ -51,7 +51,7 @@ As a node operator, you should upgrade to the [latest released version of Corda]
 
 In this release:
 
-* Corda Shell has been removed to its own repository for improved security. You can now use a stand alone shell outside of the node, or from within the node's drivers.
+* Corda Shell has been removed to its own repository for improved security. You can now use a standalone shell outside of the node, or from within the node's drivers. You can read more about using the standalone shell [here](/node/operating/shell.html#the-standalone-shell).
 * Security updates to prevent possibility of Denial of Service attacks.
 * Improvements to demos and sample code.
 * Improvements to improve compatibility with Intel Macs.


### PR DESCRIPTION
As requested by Alex Koller on Slack