### PR TITLE
DOC-4003: Quick RPC requests added

### DIFF
--- a/content/en/platform/corda/4.6/enterprise/api-rpc.md
+++ b/content/en/platform/corda/4.6/enterprise/api-rpc.md
@@ -48,11 +48,11 @@ The key RPC operations exposed by the node are:
 
 
 * `CordaRPCOps.nodeInfo`
-    * Returns the network map entry of the node, including its address and identity details as well as the platform version information
+  * Returns the network map entry of the node, including its address and identity details as well as the platform version information
 
 
 * `CordaRPCOps.currentNodeTime`
-    * Returns the current time according to the node’s clock
+  * Returns the current time according to the node’s clock. It is a 'quick RPC'. It bypasses the thread pool and other regular RPCs waiting in it, allowing the node to reply relatively quickly.
 
 
 * `CordaRPCOps.partyFromKey/CordaRPCOps.wellKnownPartyFromX500Name`

--- a/content/en/platform/corda/4.6/open-source/api-rpc.md
+++ b/content/en/platform/corda/4.6/open-source/api-rpc.md
@@ -56,7 +56,7 @@ The key RPC operations exposed by the node are:
 
 
 * `CordaRPCOps.currentNodeTime`
-    * Returns the current time according to the node’s clock
+    * Returns the current time according to the node’s clock.
 
 
 * `CordaRPCOps.partyFromKey/CordaRPCOps.wellKnownPartyFromX500Name`

--- a/content/en/platform/corda/4.7/enterprise/api-rpc.md
+++ b/content/en/platform/corda/4.7/enterprise/api-rpc.md
@@ -52,7 +52,7 @@ The key RPC operations exposed by the node are:
 
 
 * `CordaRPCOps.currentNodeTime`
-    * Returns the current time according to the node’s clock
+   * Returns the current time according to the node’s clock. It is a 'quick RPC'. It bypasses the thread pool and other regular RPCs waiting in it, allowing the node to reply relatively quickly.
 
 
 * `CordaRPCOps.partyFromKey/CordaRPCOps.wellKnownPartyFromX500Name`

--- a/content/en/platform/corda/4.7/enterprise/node/operating/clientrpc.md
+++ b/content/en/platform/corda/4.7/enterprise/node/operating/clientrpc.md
@@ -703,6 +703,10 @@ are tagged with the `@RPCSinceVersion` annotation. If you try to use a method th
 for, an `UnsupportedOperationException` is thrown. If you want to know the version of the server, just use the
 `protocolVersion` property in Kotlin or `getProtocolVersion` in Java.
 
+{{< note >}}
+`getProtocolVersion` is a 'quick RPC'. It bypasses the thread pool and other regular RPCs waiting in it, allowing the node to reply relatively quickly.
+{{< /note >}}
+
 The RPC client library defaults to requiring the platform version it was built with. That means if you use the client
 library released as part of Corda N, then the node it connects to must be of version N or above. This is checked when
 the client first connects. If you want to override this behaviour, you can alter the `minimumServerProtocolVersion`

--- a/content/en/platform/corda/4.7/open-source/api-rpc.md
+++ b/content/en/platform/corda/4.7/open-source/api-rpc.md
@@ -56,7 +56,7 @@ The key RPC operations exposed by the node are:
 
 
 * `CordaRPCOps.currentNodeTime`
-    * Returns the current time according to the node’s clock
+  * Returns the current time according to the node’s clock. It is a 'quick RPC'. It bypasses the thread pool and other regular RPCs waiting in it, allowing the node to reply relatively quickly.
 
 
 * `CordaRPCOps.partyFromKey/CordaRPCOps.wellKnownPartyFromX500Name`

--- a/content/en/platform/corda/4.7/open-source/clientrpc.md
+++ b/content/en/platform/corda/4.7/open-source/clientrpc.md
@@ -606,6 +606,10 @@ are tagged with the `@RPCSinceVersion` annotation. If you try to use a method th
 for, an `UnsupportedOperationException` is thrown. If you want to know the version of the server, just use the
 `protocolVersion` property in Kotlin or `getProtocolVersion` in Java.
 
+{{< note >}}
+`getProtocolVersion` is a 'quick RPC'. It bypasses the thread pool and other regular RPCs waiting in it, allowing the node to reply relatively quickly.
+{{< /note >}}
+
 The RPC client library defaults to requiring the platform version it was built with. That means if you use the client
 library released as part of Corda N, then the node it connects to must be of version N or above. This is checked when
 the client first connects. If you want to override this behaviour, you can alter the `minimumServerProtocolVersion`

--- a/content/en/platform/corda/4.8/enterprise/api-rpc.md
+++ b/content/en/platform/corda/4.8/enterprise/api-rpc.md
@@ -52,7 +52,7 @@ The key RPC operations exposed by the node are:
 
 
 * `CordaRPCOps.currentNodeTime`
-    * Returns the current time according to the node’s clock
+  * Returns the current time according to the node’s clock. It is a 'quick RPC'. It bypasses the thread pool and other regular RPCs waiting in it, allowing the node to reply relatively quickly.
 
 
 * `CordaRPCOps.partyFromKey/CordaRPCOps.wellKnownPartyFromX500Name`

--- a/content/en/platform/corda/4.8/enterprise/node/operating/clientrpc.md
+++ b/content/en/platform/corda/4.8/enterprise/node/operating/clientrpc.md
@@ -703,6 +703,10 @@ are tagged with the `@RPCSinceVersion` annotation. If you try to use a method th
 for, an `UnsupportedOperationException` is thrown. If you want to know the version of the server, just use the
 `protocolVersion` property in Kotlin or `getProtocolVersion` in Java.
 
+{{< note >}}
+`getProtocolVersion` is a 'quick RPC'. It bypasses the thread pool and other regular RPCs waiting in it, allowing the node to reply relatively quickly.
+{{< /note >}}
+
 The RPC client library defaults to requiring the platform version it was built with. That means if you use the client
 library released as part of Corda N, then the node it connects to must be of version N or above. This is checked when
 the client first connects. If you want to override this behaviour, you can alter the `minimumServerProtocolVersion`

--- a/content/en/platform/corda/4.8/open-source/api-rpc.md
+++ b/content/en/platform/corda/4.8/open-source/api-rpc.md
@@ -56,7 +56,7 @@ The key RPC operations exposed by the node are:
 
 
 * `CordaRPCOps.currentNodeTime`
-    * Returns the current time according to the node’s clock
+  * Returns the current time according to the node’s clock. It is a 'quick RPC'. It bypasses the thread pool and other regular RPCs waiting in it, allowing the node to reply relatively quickly.
 
 
 * `CordaRPCOps.partyFromKey/CordaRPCOps.wellKnownPartyFromX500Name`

--- a/content/en/platform/corda/4.8/open-source/clientrpc.md
+++ b/content/en/platform/corda/4.8/open-source/clientrpc.md
@@ -606,6 +606,10 @@ are tagged with the `@RPCSinceVersion` annotation. If you try to use a method th
 for, an `UnsupportedOperationException` is thrown. If you want to know the version of the server, just use the
 `protocolVersion` property in Kotlin or `getProtocolVersion` in Java.
 
+{{< note >}}
+`getProtocolVersion` is a 'quick RPC'. It bypasses the thread pool and other regular RPCs waiting in it, allowing the node to reply relatively quickly.
+{{< /note >}}
+
 The RPC client library defaults to requiring the platform version it was built with. That means if you use the client
 library released as part of Corda N, then the node it connects to must be of version N or above. This is checked when
 the client first connects. If you want to override this behaviour, you can alter the `minimumServerProtocolVersion`

--- a/content/en/platform/corda/4.9/community/api-rpc.md
+++ b/content/en/platform/corda/4.9/community/api-rpc.md
@@ -56,7 +56,7 @@ The key RPC operations exposed by the node are:
 
 
 * `CordaRPCOps.currentNodeTime`
-    * Returns the current time according to the node’s clock
+  * Returns the current time according to the node’s clock. It is a 'quick RPC'. It bypasses the thread pool and other regular RPCs waiting in it, allowing the node to reply relatively quickly.
 
 
 * `CordaRPCOps.partyFromKey/CordaRPCOps.wellKnownPartyFromX500Name`

--- a/content/en/platform/corda/4.9/community/clientrpc.md
+++ b/content/en/platform/corda/4.9/community/clientrpc.md
@@ -606,6 +606,10 @@ are tagged with the `@RPCSinceVersion` annotation. If you try to use a method th
 for, an `UnsupportedOperationException` is thrown. If you want to know the version of the server, just use the
 `protocolVersion` property in Kotlin or `getProtocolVersion` in Java.
 
+{{< note >}}
+`getProtocolVersion` is a 'quick RPC'. It bypasses the thread pool and other regular RPCs waiting in it, allowing the node to reply relatively quickly.
+{{< /note >}}
+
 The RPC client library defaults to requiring the platform version it was built with. That means if you use the client
 library released as part of Corda N, then the node it connects to must be of version N or above. This is checked when
 the client first connects. If you want to override this behaviour, you can alter the `minimumServerProtocolVersion`

--- a/content/en/platform/corda/4.9/enterprise/api-rpc.md
+++ b/content/en/platform/corda/4.9/enterprise/api-rpc.md
@@ -52,7 +52,7 @@ The key RPC operations exposed by the node are:
 
 
 * `CordaRPCOps.currentNodeTime`
-    * Returns the current time according to the node’s clock
+  * Returns the current time according to the node’s clock. It is a 'quick RPC'. It bypasses the thread pool and other regular RPCs waiting in it, allowing the node to reply relatively quickly.
 
 
 * `CordaRPCOps.partyFromKey/CordaRPCOps.wellKnownPartyFromX500Name`

--- a/content/en/platform/corda/4.9/enterprise/node/operating/clientrpc.md
+++ b/content/en/platform/corda/4.9/enterprise/node/operating/clientrpc.md
@@ -703,6 +703,10 @@ are tagged with the `@RPCSinceVersion` annotation. If you try to use a method th
 for, an `UnsupportedOperationException` is thrown. If you want to know the version of the server, just use the
 `protocolVersion` property in Kotlin or `getProtocolVersion` in Java.
 
+{{< note >}}
+`getProtocolVersion` is a 'quick RPC'. It bypasses the thread pool and other regular RPCs waiting in it, allowing the node to reply relatively quickly.
+{{< /note >}}
+
 The RPC client library defaults to requiring the platform version it was built with. That means if you use the client
 library released as part of Corda N, then the node it connects to must be of version N or above. This is checked when
 the client first connects. If you want to override this behaviour, you can alter the `minimumServerProtocolVersion`

--- a/content/en/platform/corda/5.0-dev-preview-1/nodes/operating/authentication/authentication.md
+++ b/content/en/platform/corda/5.0-dev-preview-1/nodes/operating/authentication/authentication.md
@@ -13,7 +13,7 @@ description: >
 
 Use this guide to configure authentication and authorization for HTTP-RPC, using basic authentication or Azure Active Directory (AD) single sign-on (SSO).
 
-Most of the endpoints exposed via HTTP-RPC require authentication. `getProtocolVersion` is the only endpoint that doesn't require authentication.
+Most of the endpoints exposed via HTTP-RPC require authentication. `getProtocolVersion` is the only endpoint that doesn't require authentication. It is also a 'quick RPC'. It bypasses the thread pool that handles other RPCs. This allows the node to reply relatively quickly even if it is busy processing lots of regular RPCs.
 
 You can test the authentication functionality using Swagger UI (if enabled):
 

--- a/content/en/platform/corda/5.0-dev-preview-1/nodes/operating/configure-nodeconf.md
+++ b/content/en/platform/corda/5.0-dev-preview-1/nodes/operating/configure-nodeconf.md
@@ -91,7 +91,8 @@ Start the node to verify that you have set up HTTP-RPC correctly. You should see
 [INFO] 2021-05-28T16:20:27,931Z [NodeLifecycleEventsDistributor-0] flow.StartableFlowsRetriever.get - net.corda.httprpcdemo.workflows.MessageStateIssue {}
 ```
 
-A Swagger UI address is included in the output. Use this address to test the various endpoints. As a simple smoke test, you can use any of the `getProtocolVersion` calls. If the test is successful and HTTP-RPC is configured correctly, it will return a `200 OK` status and an integer in the response body (the actual value depends on which Corda version the node is running).
+A Swagger UI address is included in the output. Use this address to test the various endpoints. As a simple smoke test, you can use any of the `getProtocolVersion` calls. These calls bypass the thread pool that handles regular Corda RPCs. They can be processed quickly even when the pool is processing a large number of other RPCs. If the test is successful and HTTP-RPC is configured correctly, it will return a `200 OK` status and an integer in the response body (the actual value depends on which Corda version the node is running).
+“quick RPCs”. These are RPCs that are not processed by the thread-pool that handles regular Corda RPCs. Instead, quick RPCs bypass the thread pool allowing the node to reply relatively quickly even if it is busy processing lots of regular RPCs.
 
 ### Common errors
 


### PR DESCRIPTION
Recent delivery a new feature - “quick RPCs”. These are RPCs that are not processed by the thread-pool that handles regular Corda RPCs. Instead, quick RPCs bypass the thread pool allowing the node to reply relatively quickly even if it is busy processing lots of regular RPCs.

The following Corda RPCs have been made into quick RPCs:

getProtocolVersion()

currentNodeTime()

