### PR TITLE
doc-4157-code-highlighting-issue

### DIFF
--- a/content/en/platform/corda/5.0-dev-preview-2/getting-started/fast-feedback-with-the-simulator/fast-feedback-with-the-simulator.md
+++ b/content/en/platform/corda/5.0-dev-preview-2/getting-started/fast-feedback-with-the-simulator/fast-feedback-with-the-simulator.md
@@ -86,7 +86,7 @@ Note the green tick on the left indicating that the test was successful. You can
 
 First the test class instantiates `MemberX500Name` for two actors. `MemberX500Name` is the primary way that identities are represented on a Corda [application Network](../../introduction/key-concepts.html#application-network). `MemberX500Name` has a state method `parse()` that turns the string representation of a members identity into a `MemberX500Name` object.
 1. Set up Alice and Bob identities:
-   ```Kotlinclass
+   ```kotlin
    MyFirstFlowTest {
 
        // Names picked to match the corda network in config/dev-net.json
@@ -94,42 +94,42 @@ First the test class instantiates `MemberX500Name` for two actors. `MemberX500Na
        private val bobX500 = MemberX500Name.parse("CN=Bob, OU=Test Dept, O=R3, L=London, C=GB")
    ```
 2. Declare the test method in the standard way for JUnit test, with a `@Test` annotation:
-   ```Kotlinclass
+   ```kotlin
        @Test
        fun `test that MyFirstFLow returns correct message`() {
    ```      
 3. Instantiate a `Simulator` class:
-   ```Kotlinclass
+   ```kotlin
           // Instantiate an instance of the Simulator
            val simulator = Simulator()
     ```
    To find out more about this class, read the [README.md from the source code](https://github.com/corda/corda-runtime-os/blob/release/os/5.0/simulator/README.md).
 
 4. Convert the `MemberX500Name` for Alice and Bob into `HoldingIdentities` using the `HoldingIdentity` static method. The `HoldingIdentity` in Corda holds the `MemberX500Name` and the `GroupId` which is the unique identifier for the application network. However, the class used here is the simulated version provided by Simulator; that is `net.corda.simulator.HoldingIdentity` rather than `net.corda.virtualnode.HoldingEntity`.
-   ```Kotlinclass
+   ```kotlin
            // Create Alice's and Bob HoldingIDs
            val aliceHoldingID = HoldingIdentity.Companion.create(aliceX500)
            val bobHoldingID = HoldingIdentity.Companion.create(bobX500)
    ```        
 5. Use Simulator to create virtual nodes for Alice and Bob from their respective holding identities. The second argument allows you to specify which flows should be loaded up to each virtual node. In this case, Alice runs the initiating flow, with Bob running the responder flow.
-   ```Kotlinclass
+   ```kotlin
            // Create Alice and Bob's virtual nodes, including the classes of the flows which will be registered on each node.
            val aliceVN = simulator.createVirtualNode(aliceHoldingID, MyFirstFlow::class.java)
            val bobVN = simulator.createVirtualNode(bobHoldingID, MyFirstFlowResponder::class.java)
     ```
     You can read more about initiating flows and responder flows in the section on *[Your first flow ](../first-flow.html#initiating-and-responding-flows)*.
 6. Create the arguments to pass to the flow. In the flow file `MyFirstFlow.kt`, create a class `MyFirstFlowArguments` specifically for holding the flow start arguments:
-   ```Kotlinclass
+   ```kotlin
    // A class to hold the arguments required to start the flow
    class MyFirstFlowStartArgs(val otherMember: MemberX500Name, val message: String)
    ```
    Use the same class to specify that the message needs to go to Bob and the message should be "Hello Bob":
-   ```Kotlinclass
+   ```kotlin
            // Create an instance of the MyFirstFlowStartArgs which contains the request arguments for starting the flow
            val myFirstFlowStartArgs = MyFirstFlowStartArgs(bobX500, "Hello Bob")
    ```
    If running this flow on Corda itself, you would send the following `requestBody` over HTTP-RPC:
-   ```Kotlinclass
+   ```kotlin
     {
        "clientRequestId": "r1",
        "flowClassName": "com.r3.developers.csdetemplate.MyFirstFlow",
@@ -137,7 +137,7 @@ First the test class instantiates `MemberX500Name` for two actors. `MemberX500Na
    }
    ```
    When using Simulator in tests, use the `RequestData` class, which simulates the `requestBody`:
-   ```Kotlinclass
+   ```kotlin
            // Create a requestData object
            val requestData = RequestData.create(
                "request no 1",        // A unique reference for the instance of the flow request
@@ -147,12 +147,12 @@ First the test class instantiates `MemberX500Name` for two actors. `MemberX500Na
    ```
 7. Pass the `requestData` to the `callflow()` function on Alice’s virtual node, to trigger the flow on Simulator.
    Simulator simulates running the flow and responder flow, substituting simulated services as required, and returning a flow response String.
-   ```Kotlinclass
+   ```kotlin
            // Call the Flow on Alice's virtual node and capture the response from the flow
            val flowResponse = aliceVN.callFlow(requestData)
    ```
 8. Test that the response received matches the response expected using an assert method:
-   ```Kotlinclass
+   ```kotlin
            // Check that the flow has returned the expected string
            assert(flowResponse == "Hello Alice, best wishes from Bob")
    ```        


### PR DESCRIPTION
After time digging into CSS, this turned out to not be a CSS file issue, but rather an error in the code style invoked in the markdown. Here is the old version followed by the fixed version:

<img width="791" alt="Screenshot 2022-10-14 at 15 34 36" src="https://user-images.githubusercontent.com/112863914/195880323-1e917ddc-2eb7-42cb-b3d4-fc031a7dd7a3.png">

<img width="735" alt="Screenshot 2022-10-14 at 15 35 26" src="https://user-images.githubusercontent.com/112863914/195880334-b3b3577d-1e01-41dd-8f60-fde6d079d7a5.png">
