### PR TITLE
doc-4165-code-heading-change

### DIFF
--- a/themes/doks/assets/scss/components/_code.scss
+++ b/themes/doks/assets/scss/components/_code.scss
@@ -18,6 +18,7 @@ h6 {
   kbd,
   samp {
     font-size: inherit;
+    background: none;
   }
 }
 


### PR DESCRIPTION
Heading code style parameter added to override the global code style, without affecting the code style in regular content. In image, you can see that the regular content code is unaffected, but the headings are changed as discussed.
<img width="735" alt="Screenshot 2022-10-17 at 13 24 08" src="https://user-images.githubusercontent.com/112863914/196177264-91333351-d527-49a2-be48-dd6dc4eabc40.png">
