### PR TITLE
Removed updates for 4.10 added mistakenly to 4.9 by the following com…

### DIFF
--- a/content/en/platform/corda/4.9/community/node-administration.md
+++ b/content/en/platform/corda/4.9/community/node-administration.md
@@ -140,7 +140,6 @@ In order to ensure that a Jolokia agent is instrumented with the JVM run-time, y
 
 The following JMX statistics are exported:
 
-* Node status, indicating what the node is currently doing. The status is published as: `net.corda.Node.Status`, and is available almost immediately at startup.
 * Corda specific metrics: flow information (total started, finished, in-flight; flow duration by flow type), attachments (count)
 * Apache Artemis metrics: queue information for P2P and RPC services
 * JVM statistics: classloading, garbage collection, memory, runtime, threading, operating system

--- a/content/en/platform/corda/4.9/enterprise/operations/deployment/running-a-node.md
+++ b/content/en/platform/corda/4.9/enterprise/operations/deployment/running-a-node.md
@@ -208,9 +208,7 @@ To enable export of JMX metrics over HTTP via [Jolokia](https://jolokia.org/), r
 
 `java -Dcapsule.jvm.args="-javaagent:drivers/jolokia-jvm-1.3.7-agent.jar=port=7005" -jar corda.jar`
 
-This command line will start the node with JMX metrics accessible via HTTP on port 7005. The first metric a Corda developer will see when monitoring is the node status, indicating what the node is currently doing.
-The status is published as: `net.corda.Node.Status`, and is available almost immediately at startup.
-
+This command line will start the node with JMX metrics accessible via HTTP on port 7005. 
 
 See [Monitoring via Jolokia](../../node/operating/node-administration.html#monitoring-via-jolokia) for further details.
 


### PR DESCRIPTION
Removed updates for 4.10 added mistakenly to 4.9 by the following commit 

[https://github.com/corda/corda-docs-portal/pull/637/commits/f686aa4dd9b08ae3710d83ddf9d9260a7800944e](https://github.com/corda/corda-docs-portal/pull/637/commits/f686aa4dd9b08ae3710d83ddf9d9260a7800944e
)
...for the following ticket:

[https://r3-cev.atlassian.net/browse/DOC-3997 ("Publishing node status in logging parameters"
](https://r3-cev.atlassian.net/browse/DOC-3997)

These changes will be introduced into 4.10 by the following ticket:

[https://r3-cev.atlassian.net/browse/DOC-4230](https://r3-cev.atlassian.net/browse/DOC-4230)