### PR TITLE
ENT-8792 - Fixed mentions of Postgres 13.3, should be 13.8

### DIFF
--- a/content/en/platform/corda/4.8/enterprise/node/setup/host-prereq.md
+++ b/content/en/platform/corda/4.8/enterprise/node/setup/host-prereq.md
@@ -52,7 +52,7 @@ weight: 2
 |Microsoft|x86-64|Azure SQL,SQL Server 2017|Microsoft JDBC Driver 6.4|
 |Oracle|x86-64|11gR2|Oracle JDBC 6|
 |Oracle|x86-64|12cR2|Oracle JDBC 8|
-|PostgreSQL|x86-64|9.6, 10.10, 11.5, 13.3|PostgreSQL JDBC Driver 42.1.4 / 42.2.9|
+|PostgreSQL|x86-64|9.6, 10.10, 11.5, 13.8|PostgreSQL JDBC Driver 42.1.4 / 42.2.9|
 
 
 {{< /table >}}

--- a/content/en/platform/corda/4.8/enterprise/platform-support-matrix.md
+++ b/content/en/platform/corda/4.8/enterprise/platform-support-matrix.md
@@ -97,7 +97,7 @@ Install the **Java 8 JDK**. Corda does not currently support Java 9 or higher.
 |Microsoft|x86-64|Azure SQL,SQL Server 2017|Microsoft JDBC Driver 6.4|
 |Oracle|x86-64|11gR2|Oracle JDBC 6|
 |Oracle|x86-64|12cR2|Oracle JDBC 8|
-|PostgreSQL|x86-64|9.6, 10.10, 11.5, 13.3|PostgreSQL JDBC Driver 42.1.4 / 42.2.9|
+|PostgreSQL|x86-64|9.6, 10.10, 11.5, 13.8|PostgreSQL JDBC Driver 42.1.4 / 42.2.9|
 
 {{< /table >}}
 

--- a/content/en/platform/corda/4.8/enterprise/release-notes-enterprise.md
+++ b/content/en/platform/corda/4.8/enterprise/release-notes-enterprise.md
@@ -193,7 +193,7 @@ In this patch release:
 * A fix has been introduced to reduce memory consumption during batched transaction resolution of large backchains.
 * Support has been introduced for RedHat Enterprise Linux 8.x in Corda 4.8.1.
 * Performance verification of the HA Notary with CockroachDB 20.2.8 has been carried out - performance is not worse in comparison to the HA Notary configured on CockroachDB 20.1.6.
-* Support for PostgreSQL 13.3 for node databases has been added.
+* Support for PostgreSQL 13.8 for node databases has been added.
 * Hibernate ORM has been updated to version to 5.4.32 to remove a security concern.
 * The [Node management console](../../../../../en/platform/corda/4.8/enterprise/node/management-console.html#node-management-console) configuration has been updated. Configuration is now set in `node.management.plugin.middleware`, no longer `node.admin.middleware`.
 * The [Flow management console](../../../../../en/platform/corda/4.8/enterprise/node/node-flow-management-console.html#flow-management-console) configuration has been updated. Configuration is now set in `flow.management.plugin.middleware`, no longer `flow.admin.middleware`.

--- a/content/en/platform/corda/4.9/enterprise/node/setup/host-prereq.md
+++ b/content/en/platform/corda/4.9/enterprise/node/setup/host-prereq.md
@@ -52,7 +52,7 @@ weight: 2
 |Microsoft|x86-64|Azure SQL,SQL Server 2017|Microsoft JDBC Driver 6.4|
 |Oracle|x86-64|11gR2|Oracle JDBC 6|
 |Oracle|x86-64|12cR2|Oracle JDBC 8|
-|PostgreSQL|x86-64|9.6, 10.10, 11.5, 13.3|PostgreSQL JDBC Driver 42.1.4 / 42.2.9|
+|PostgreSQL|x86-64|9.6, 10.10, 11.5, 13.8|PostgreSQL JDBC Driver 42.1.4 / 42.2.9|
 
 
 {{< /table >}}

--- a/content/en/platform/corda/4.9/enterprise/platform-support-matrix.md
+++ b/content/en/platform/corda/4.9/enterprise/platform-support-matrix.md
@@ -97,7 +97,7 @@ Install the **Java 8 JDK**. Corda does not currently support Java 9 or higher.
 |Microsoft|x86-64|Azure SQL,SQL Server 2017|Microsoft JDBC Driver 6.4|
 |Oracle|x86-64|19c|Oracle JDBC 6|
 |Oracle|x86-64|19c|Oracle JDBC 8|
-|PostgreSQL|x86-64|9.6, 10.10, 11.5, 13.3|PostgreSQL JDBC Driver 42.1.4 / 42.2.9|
+|PostgreSQL|x86-64|9.6, 10.10, 11.5, 13.8|PostgreSQL JDBC Driver 42.1.4 / 42.2.9|
 
 {{< /table >}}
 


### PR DESCRIPTION
Updated references to Postgres 13.3 and changed to 13.8, including the 4.8.1 release notes.