### PR TITLE
Revert "Doc 4335: Broken link fixed in What is a CorDapp?"

### DIFF
--- a/content/en/platform/corda/4.8/enterprise/cordapps/cordapp-overview.md
+++ b/content/en/platform/corda/4.8/enterprise/cordapps/cordapp-overview.md
@@ -96,6 +96,6 @@ Each node owner installs this CorDapp onto their node. They can then issue, trad
 
 Ready to get started with CorDapps?
 
-* [Get set up for CorDapp development](../../../../../../en/platform/corda/4.8/enterprise/cordapps/getting-set-up.html).
-* [Run a sample CorDapp](../../../../../../en/platform/corda/4.8/enterprise/cordapps/tutorial-cordapp.html).
-* [Build a CorDapp](../../../../../../en/platform/corda/4.8/enterprise/cordapps/cordapp-build-systems.html).
+* [Get set up for CorDapp development](../../../../../../en/platform/corda/4.8/enterprise/cordapps/getting-set-up.md).
+* [Run a sample CorDapp](../../../../../../en/platform/corda/4.8/enterprise/cordapps/tutorial-cordapp.md).
+* [Build a CorDapp](../../../../../en/platform/corda/4.8/enterprise/cordapps/cordapp-build-systems.md).

--- a/content/en/platform/corda/4.9/enterprise/cordapps/cordapp-overview.md
+++ b/content/en/platform/corda/4.9/enterprise/cordapps/cordapp-overview.md
@@ -96,6 +96,6 @@ Each node owner installs this CorDapp onto their node. They can then issue, trad
 
 Ready to get started with CorDapps?
 
-* [Get set up for CorDapp development](../../../../../../en/platform/corda/4.9/enterprise/cordapps/getting-set-up.html).
-* [Run a sample CorDapp](../../../../../../en/platform/corda/4.9/enterprise/cordapps/tutorial-cordapp.html).
-* [Build a CorDapp](../../../../../../en/platform/corda/4.9/enterprise/cordapps/cordapp-build-systems.html).
+* [Get set up for CorDapp development](../../../../../../en/platform/corda/4.9/enterprise/cordapps/getting-set-up.md).
+* [Run a sample CorDapp](../../../../../../en/platform/corda/4.9/enterprise/cordapps/tutorial-cordapp.md).
+* [Build a CorDapp](../../../../../en/platform/corda/4.9/enterprise/cordapps/cordapp-build-systems.md).


### PR DESCRIPTION
URL link in 4.8 not working in staging site. 