### PR TITLE
Doc 4371: Update CSDE docs to states that ports 5432, 7000 & 8888 should be reserved 

### DIFF
--- a/content/en/platform/corda/5.0-beta/getting-started/prerequisites/prerequisites.md
+++ b/content/en/platform/corda/5.0-beta/getting-started/prerequisites/prerequisites.md
@@ -42,7 +42,7 @@ Most of the computers that we use to develop, build, and test Corda 5 have:
 These are not minimum specifications.
 This what is known to work with the code as of Developer Preview 2.-->
 
-## Required CSDE ports
+## Required CSDE Ports
 
 The current version of the [Corda combined worker](../cordapp-standard-development-environment/csde.html#gradle-helpers-for-the-combined-worker) runs on ports 7000, 5432, and 8888. Reserve these ports to avoid errors. For example, some Mac operating systems use port 7000 for the system Control Center. The following section describes how to make the port available.
 

--- a/content/en/platform/corda/5.0-beta/getting-started/prerequisites/prerequisites.md
+++ b/content/en/platform/corda/5.0-beta/getting-started/prerequisites/prerequisites.md
@@ -44,7 +44,6 @@ The current version of the [Corda combined worker](../cordapp-standard-developme
 
 ### Disabling Airplay Receiver on Mac
 
-Some Mac operating systems use port 7000 for the system Control Center.
 You can check if your Mac is using port 7000 for Control Center by running `lsof -i :7000` from your terminal. If you see the following results, you must disable Airplay Receiver:
 
 ```shell

--- a/content/en/platform/corda/5.0-beta/getting-started/prerequisites/prerequisites.md
+++ b/content/en/platform/corda/5.0-beta/getting-started/prerequisites/prerequisites.md
@@ -40,7 +40,10 @@ This what is known to work with the code as of Developer Preview 2.-->
 
 ## Additional Configuration for Mac
 
-The current version of the [Corda combined worker](../cordapp-standard-development-environment/csde.html#gradle-helpers-for-the-combined-worker) runs on port 7000.
+The current version of the [Corda combined worker](../cordapp-standard-development-environment/csde.html#gradle-helpers-for-the-combined-worker) runs on ports 7000, 5432, and 8888.
+
+### Disabling Airplay on Mac
+
 Some Mac operating systems use port 7000 for the system Control Center.
 You can check if your Mac is using port 7000 for Control Center by running `lsof -i :7000` from your terminal. If you see the following results, you must disable Airplay Receiver:
 

--- a/content/en/platform/corda/5.0-beta/getting-started/prerequisites/prerequisites.md
+++ b/content/en/platform/corda/5.0-beta/getting-started/prerequisites/prerequisites.md
@@ -38,11 +38,11 @@ Most of the computers that we use to develop, build, and test Corda 5 have:
 These are not minimum specifications.
 This what is known to work with the code as of Developer Preview 2.-->
 
-## Additional Configuration for Mac
+## Required CSDE ports
 
-The current version of the [Corda combined worker](../cordapp-standard-development-environment/csde.html#gradle-helpers-for-the-combined-worker) runs on ports 7000, 5432, and 8888.
+The current version of the [Corda combined worker](../cordapp-standard-development-environment/csde.html#gradle-helpers-for-the-combined-worker) runs on ports 7000, 5432, and 8888. Reserve these ports to avoid errors. For example, some Mac operating systems use port 7000 for the system Control Center. The following section describes how to make the port available.
 
-### Disabling Airplay on Mac
+### Disabling Airplay Receiver on Mac
 
 Some Mac operating systems use port 7000 for the system Control Center.
 You can check if your Mac is using port 7000 for Control Center by running `lsof -i :7000` from your terminal. If you see the following results, you must disable Airplay Receiver:


### PR DESCRIPTION
Update CSDE docs to states that ports 5432, 7000 & 8888 should be reserved.