### PR TITLE
DOC-4387  - replaced 'open-source' in 4.9 links with 'community'

### DIFF
--- a/content/en/platform/corda/4.9/enterprise/cordapps/api-confidential-identity.md
+++ b/content/en/platform/corda/4.9/enterprise/cordapps/api-confidential-identity.md
@@ -45,7 +45,7 @@ counterparty we want to exchange confidential identities with. It returns a mapp
 and the counterparty to their new confidential identities. In the future, this flow will be extended to handle swapping
 identities with multiple parties at once.
 
-You can see an example of using `SwapIdentitiesFlow` in <a href="../../../../../../en/api-ref/corda/4.9/open-source/kotlin/corda/net.corda.finance.flows/-two-party-deal-flow/index.md">`TwoPartyDealFlow.kt`</a> .
+You can see an example of using `SwapIdentitiesFlow` in <a href="../../../../../../en/api-ref/corda/4.9/community/kotlin/corda/net.corda.finance.flows/-two-party-deal-flow/index.md">`TwoPartyDealFlow.kt`</a> .
 
 `SwapIdentitiesFlow` goes through the following key steps:
 

--- a/content/en/platform/corda/4.9/enterprise/cordapps/api-states.md
+++ b/content/en/platform/corda/4.9/enterprise/cordapps/api-states.md
@@ -14,7 +14,7 @@ weight: 60
 
 # CorDapp states
 
-Before you read this article, make sure you understand the [state key concepts](../../../../../../en/platform/corda/4.9/open-source/key-concepts-states.html).
+Before you read this article, make sure you understand the [state key concepts](../../../../../../en/platform/corda/4.9/community/key-concepts-states.html).
 
 In Corda, a contract state (or just ‘state’) stores data that the CorDapp needs to move from one transaction to another.
 

--- a/content/en/platform/corda/4.9/enterprise/financial-model.md
+++ b/content/en/platform/corda/4.9/enterprise/financial-model.md
@@ -33,7 +33,7 @@ A type used to define the underlying financial product in a transaction.
 
 ## Amount
 
-The [Amount](../../../../../en/api-ref/corda/4.9/open-source/kotlin/corda/net.corda.core.contracts/-amount/index.html) class represents an amount of
+The [Amount](../../../../../en/api-ref/corda/4.9/community/kotlin/corda/net.corda.core.contracts/-amount/index.html) class represents an amount of
 a fungible asset. It is a generic class which wraps around the token. For example, the `Amount` could be:
 * The standard JDK type `Currency`.
 * An `Issued` instance.

--- a/content/en/platform/corda/4.9/enterprise/json.md
+++ b/content/en/platform/corda/4.9/enterprise/json.md
@@ -29,7 +29,7 @@ connection to the node (see [Interacting with the node](../../../../../en/platfo
 
 For the full API details, see the:
 
-* [Kotlin API docs](../../../../../en/api-ref/corda/4.9/open-source/kotlin/corda/net.corda.client.jackson/-jackson-support/index.html)
+* [Kotlin API docs](../../../../../en/api-ref/corda/4.9/community/kotlin/corda/net.corda.client.jackson/-jackson-support/index.html)
 * [JavaDoc](../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/client/jackson/JacksonSupport.html)
 
 {{< tabs name="tabs-1" >}}

--- a/content/en/platform/corda/4.9/enterprise/network-bootstrapper.md
+++ b/content/en/platform/corda/4.9/enterprise/network-bootstrapper.md
@@ -416,7 +416,7 @@ To register a package, you need to provide the:
 
 We've created a sample CorDapp (available in [Java](https://github.com/corda/samples-java/tree/master/Basic/cordapp-example) and [Kotlin](https://github.com/corda/samples-kotlin/tree/master/Basic/cordapp-example)) you can use to practice initializing a simple network and registering and unregistering a package namespace.
 
-1. Check the sample CorDapp out, then follow the [instructions to build it](../../../../../en/platform/corda/4.9/open-source/tutorial-cordapp.html#building-the-example-cordapp).
+1. Check the sample CorDapp out, then follow the [instructions to build it](../../../../../en/platform/corda/4.9/community/tutorial-cordapp.html#building-the-example-cordapp).
 
 {{< note >}}
 You can point to any existing bootstrapped network on Corda. This will update the associated network parameters file for that network).
@@ -506,4 +506,4 @@ bootstrapper [-hvV] [--copy-cordapps=<copyCordapps>] [--dir=<dir>]
 
 ### Sub-commands
 
-`install-shell-extensions`: Installs the `bootstrapper` alias and auto-completion for bash and zsh. See [Shell extentions for CLI applications](../../../../../en/platform/corda/4.9/open-source/cli-application-shell-extensions.html#shell-extensions-for-cli-applications).
+`install-shell-extensions`: Installs the `bootstrapper` alias and auto-completion for bash and zsh. See [Shell extentions for CLI applications](../../../../../en/platform/corda/4.9/community/cli-application-shell-extensions.html#shell-extensions-for-cli-applications).

--- a/content/en/platform/corda/4.9/enterprise/network/compatibility-zones.md
+++ b/content/en/platform/corda/4.9/enterprise/network/compatibility-zones.md
@@ -28,7 +28,7 @@ have agreed to trade with each other.
 ### Bootstrapping a compatibility zone
 
 You can easily bootstrap a compatibility zone for testing or pre-production use with either the
-network-bootstrapper or the [Network Builder](../../../../../../en/platform/corda/4.9/open-source/network-builder.md) tools.
+network-bootstrapper or the [Network Builder](../../../../../../en/platform/corda/4.9/community/network-builder.md) tools.
 
 
 ### Joining an existing compatibility zone

--- a/content/en/platform/corda/4.9/enterprise/node-explorer.md
+++ b/content/en/platform/corda/4.9/enterprise/node-explorer.md
@@ -132,7 +132,7 @@ To see a geographical view of your network, click **Network** in the left-hand s
 
 {{< note >}}
 
-The geographical location of each node is based on the <a href="../../../../../en/api-ref/corda/4.9/open-source/kotlin/corda/net.corda.core.identity/-corda-x500-name/index.html">`locality` property of the node's registered CordaX500 name</a>.
+The geographical location of each node is based on the <a href="../../../../../en/api-ref/corda/4.9/community/kotlin/corda/net.corda.core.identity/-corda-x500-name/index.html">`locality` property of the node's registered CordaX500 name</a>.
 
 {{< /note >}}
 

--- a/content/en/platform/corda/4.9/enterprise/node/collaborative-recovery/ledger-recovery-automatic.md
+++ b/content/en/platform/corda/4.9/enterprise/node/collaborative-recovery/ledger-recovery-automatic.md
@@ -168,7 +168,7 @@ In case of failure, the usage of standard Corda flows for transmission of artifa
 Upon successful completion of the automatic LedgerRecover, all `ReconciliationStatus`es initiated by the requester node (of the recovery) are refreshed. This is done so that newly acquired transactions will not show up as difference in the reconciliation results.
 
 {{< note >}}
-When recovered transactions are persisted, these will trigger the same events as were triggered when the transaction was originally persisted (before the disaster). If users are subscribing to vault-observable feeds (see [documentation on updates](../../../../../../../en/api-ref/corda/4.9/open-source/kotlin/corda/net.corda.core.node.services/-vault-service/updates.html)), they will receive duplicate updates.
+When recovered transactions are persisted, these will trigger the same events as were triggered when the transaction was originally persisted (before the disaster). If users are subscribing to vault-observable feeds (see [documentation on updates](../../../../../../../en/api-ref/corda/4.9/community/kotlin/corda/net.corda.core.node.services/-vault-service/updates.html)), they will receive duplicate updates.
 {{< /note >}}
 
 #### Parameters

--- a/content/en/platform/corda/4.9/enterprise/node/operating/clientrpc.md
+++ b/content/en/platform/corda/4.9/enterprise/node/operating/clientrpc.md
@@ -22,17 +22,17 @@ Corda Enterprise supports two types of RPC client:
 {{< warning >}}
 The built-in Corda test webserver is deprecated and unsuitable for production use. If you want to interact with
 your node via HTTP, you will need to stand up your own webserver that connects to your node using the
-[CordaRPCClient](../../../../../../../en/api-ref/corda/4.9/open-source/javadoc/net/corda/client/rpc/CordaRPCClient.html) class. You can find an example of how to do this using the popular Spring Boot server
+[CordaRPCClient](../../../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/client/rpc/CordaRPCClient.html) class. You can find an example of how to do this using the popular Spring Boot server
 [here](https://github.com/corda/spring-webserver).
 {{< /warning >}}
 
 ## Building the Corda RPC Client
 
-To interact with your node via the `CordaRPCOps` remote interface, you need to build a client that uses the [CordaRPCClient](../../../../../../../en/api-ref/corda/4.9/open-source/javadoc/net/corda/client/rpc/CordaRPCClient.html) class. The `CordaRPCClient` class enables you to connect to your node via a message queue protocol and provides a simple RPC interface (the `CordaRPCOps` remote interface) for interacting with the node. You make calls on a JVM object as normal, and the marshalling back-and-forth is handled for you.
+To interact with your node via the `CordaRPCOps` remote interface, you need to build a client that uses the [CordaRPCClient](../../../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/client/rpc/CordaRPCClient.html) class. The `CordaRPCClient` class enables you to connect to your node via a message queue protocol and provides a simple RPC interface (the `CordaRPCOps` remote interface) for interacting with the node. You make calls on a JVM object as normal, and the marshalling back-and-forth is handled for you.
 
 ### Pre-requisites
 
-To be able to use the [CordaRPCClient](../../../../../../../en/api-ref/corda/4.9/open-source/javadoc/net/corda/client/rpc/CordaRPCClient.html) class, you must add `com.r3.corda:corda-rpc:$corda_release_version` as a `compile` dependency in your client’s `build.gradle` file. As the RPC library has a transitive dependency on a patched version of Caffeine in Corda
+To be able to use the [CordaRPCClient](../../../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/client/rpc/CordaRPCClient.html) class, you must add `com.r3.corda:corda-rpc:$corda_release_version` as a `compile` dependency in your client’s `build.gradle` file. As the RPC library has a transitive dependency on a patched version of Caffeine in Corda
 Enterprise 4.0, you must add `corda-dependencies` to the list of repositories for your project, as shown in the following example, to resolve
 this dependency:
 
@@ -45,11 +45,11 @@ repositories {
 
 ### Connecting to a node with `CordaRPCClient`
 
-The [CordaRPCClient](../../../../../../../en/api-ref/corda/4.9/open-source/javadoc/net/corda/client/rpc/CordaRPCClient.html) class has a `start` method that takes the node’s RPC address and returns a [CordaRPCConnection](../../../../../../../en/api-ref/corda/4.9/open-source/javadoc/net/corda/client/rpc/CordaRPCConnection.html).
-[CordaRPCConnection](../../../../../../../en/api-ref/corda/4.9/open-source/javadoc/net/corda/client/rpc/CordaRPCConnection.html) has a `proxy` method that takes an RPC username and password and returns a [CordaRPCOps](../../../../../../../en/api-ref/corda/4.9/open-source/javadoc/net/corda/core/messaging/CordaRPCOps.html)
+The [CordaRPCClient](../../../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/client/rpc/CordaRPCClient.html) class has a `start` method that takes the node’s RPC address and returns a [CordaRPCConnection](../../../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/client/rpc/CordaRPCConnection.html).
+[CordaRPCConnection](../../../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/client/rpc/CordaRPCConnection.html) has a `proxy` method that takes an RPC username and password and returns a [CordaRPCOps](../../../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/core/messaging/CordaRPCOps.html)
 object that you can use to interact with the node.
 
-Here is an example of using [CordaRPCClient](../../../../../../../en/api-ref/corda/4.9/open-source/javadoc/net/corda/client/rpc/CordaRPCClient.html) to connect to a node and log the current time on its internal clock:
+Here is an example of using [CordaRPCClient](../../../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/client/rpc/CordaRPCClient.html) to connect to a node and log the current time on its internal clock:
 
 {{< tabs name="tabs-1" >}}
 {{% tab name="kotlin" %}}
@@ -121,9 +121,9 @@ class ClientRpcExample {
 {{< /tabs >}}
 
 {{< warning >}}
-The returned [CordaRPCConnection](../../../../../../../en/api-ref/corda/4.9/open-source/javadoc/net/corda/client/rpc/CordaRPCConnection.html) is somewhat expensive to create and consumes a small amount of
+The returned [CordaRPCConnection](../../../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/client/rpc/CordaRPCConnection.html) is somewhat expensive to create and consumes a small amount of
 server-side resources. When you’re done with it, call `close` on it. Alternatively, you would typically employ the `use`
-method on [CordaRPCClient](../../../../../../../en/api-ref/corda/4.9/open-source/javadoc/net/corda/client/rpc/CordaRPCClient.html) which cleans up automatically after the passed-in lambda finishes. Don’t create
+method on [CordaRPCClient](../../../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/client/rpc/CordaRPCClient.html) which cleans up automatically after the passed-in lambda finishes. Don’t create
 a new proxy for every call you make - reuse an existing one.
 {{< /warning >}}
 
@@ -357,7 +357,7 @@ This approach provides at-least-once guarantees. It cannot provide exactly-once 
 
 Corda Enterprise exposes a number of custom, remote RPC interfaces.
 
-To interact with your node via any of the following interfaces, you need to build a client that uses the [MultiRPCClient](../../../../../../../en/api-ref/corda/4.9/open-source/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) class:
+To interact with your node via any of the following interfaces, you need to build a client that uses the [MultiRPCClient](../../../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) class:
 
 * `net.corda.client.rpc.proxy.AuditDataRPCOps` - This interface enables you to audit the log of RPC activity.
 * `net.corda.client.rpc.proxy.FlowRPCOps` - This interface enables you to retry a previously hospitalised flow.
@@ -372,12 +372,12 @@ All of these interfaces are located in the `:client:extensions-rpc` module.
 {{< /note >}}
 
 {{< note >}}
-`CordaRPCClient` enables you to interact with the `CordaRPCOps` remote interface. However, if you intend to interact with any of the other remote interfaces that the Corda Enterprise provides, you need to build a client that uses the [MultiRPCClient](../../../../../../../en/api-ref/corda/4.9/open-source/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) class.
+`CordaRPCClient` enables you to interact with the `CordaRPCOps` remote interface. However, if you intend to interact with any of the other remote interfaces that the Corda Enterprise provides, you need to build a client that uses the [MultiRPCClient](../../../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) class.
 {{< /note >}}
 
 ### Pre-requisites
 
-To use the functionality of the [MultiRPCClient](../../../../../../../en/api-ref/corda/4.9/open-source/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) class from a custom JVM application, you must include the following
+To use the functionality of the [MultiRPCClient](../../../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) class from a custom JVM application, you must include the following
 dependencies:
 
 ```groovy
@@ -531,10 +531,10 @@ If the reconnection cycle has started, the previously supplied `RPCConnection` m
 `RPCException` every time the remote method is called.
 
 To be notified when the connection has been re-established or, indeed, to receive notifications throughout the lifecycle of every connection, you can add one or more [RPCConnectionListeners](../../../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/client/rpc/ext/RPCConnectionListener.html) to `MultiRPCClient`.
-For more information, see [RPCConnectionListener](../../../../../../../en/api-ref/corda/4.9/open-source/javadoc/net/corda/client/rpc/ext/RPCConnectionListener.html) in the API documentation.
+For more information, see [RPCConnectionListener](../../../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/client/rpc/ext/RPCConnectionListener.html) in the API documentation.
 
 ### Specifying RPC connection parameters
-Many constructors are available for `MultiRPCClient`. This enables you to specify a variety of other configuration parameters relating to the RPC connection. The parameters for `MultiRPCClient` are largely similar to the parameters for [CordaRPCClient](../../../../../../../en/api-ref/corda/4.9/open-source/javadoc/net/corda/client/rpc/CordaRPCClient.html). For more information, see [MultiRPCClient](../../../../../../../en/api-ref/corda/4.9/open-source/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) in the API documentation.
+Many constructors are available for `MultiRPCClient`. This enables you to specify a variety of other configuration parameters relating to the RPC connection. The parameters for `MultiRPCClient` are largely similar to the parameters for [CordaRPCClient](../../../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/client/rpc/CordaRPCClient.html). For more information, see [MultiRPCClient](../../../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) in the API documentation.
 
 ## Managing RPC security
 
@@ -732,7 +732,7 @@ If TLS communications to the RPC endpoint are required, the node must be configu
 The node admin must then create a node-specific RPC certificate and key, by running the node once with the `generate-rpc-ssl-settings` command specified (see [Node command-line options](../../../../../../../en/platform/corda/4.9/enterprise/node/node-commandline.md)).
 The generated RPC TLS trust root certificate is exported to a `certificates/export/rpcssltruststore.jks` file, which should be distributed to the authorised RPC clients.
 
-The connecting `CordaRPCClient` code must then use one of the constructors with a parameter of type `ClientRpcSslOptions` ([JavaDoc](../../../../../../../en/api-ref/corda/4.9/open-source/javadoc/net/corda/client/rpc/CordaRPCClient.html)) and set this constructor
+The connecting `CordaRPCClient` code must then use one of the constructors with a parameter of type `ClientRpcSslOptions` ([JavaDoc](../../../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/client/rpc/CordaRPCClient.html)) and set this constructor
 argument with the appropriate path for the `rpcssltruststore.jks` file. The client connection will then use this to validate the RPC server handshake.
 
 Note that RPC TLS does not use mutual authentication, and delegates fine-grained user authentication and authorisation to the RPC security features detailed under [Managing RPC security](#managing-rpc-security).

--- a/content/en/platform/corda/4.9/enterprise/node/operating/monitoring-and-logging/metering-collector.md
+++ b/content/en/platform/corda/4.9/enterprise/node/operating/monitoring-and-logging/metering-collector.md
@@ -31,7 +31,7 @@ Notaries running on Corda Enterprise are also metered. The data recorded for not
 
 ### How metering data is shared
 
-The metering collection tool also contains responder flows that can be used by other nodes on the network to collect metering data from the node where the respective CorDapp is installed. This feature must be enabled by the node operator deploying a [CorDapp configuration file](../../../../../../../../en/platform/corda/4.9/open-source/cordapp-build-systems.html#cordapp-configuration-files) for the CorDapp.
+The metering collection tool also contains responder flows that can be used by other nodes on the network to collect metering data from the node where the respective CorDapp is installed. This feature must be enabled by the node operator deploying a [CorDapp configuration file](../../../../../../../../en/platform/corda/4.9/community/cordapp-build-systems.html#cordapp-configuration-files) for the CorDapp.
 
 If no configuration file is deployed, metering data will not be shared with any other network party. An example configuration file that enables metering data sharing is shown below:
 

--- a/content/en/platform/corda/4.9/enterprise/node/operating/node-database-tables.md
+++ b/content/en/platform/corda/4.9/enterprise/node/operating/node-database-tables.md
@@ -164,7 +164,7 @@ It is an append only table and the size will be fairly small.
 
 The ledger data is formed of transactions and attachments.
 In future versions this data will be encrypted using SGX.
-Read more in [Ledger](../../../../../../../en/platform/corda/4.9/open-source/key-concepts-ledger.md).
+Read more in [Ledger](../../../../../../../en/platform/corda/4.9/community/key-concepts-ledger.md).
 
 
 ### Attachments
@@ -398,7 +398,7 @@ The size should be fairly constant.
 
 ## Vault tables
 
-Read more about the vault in [Vault](../../../../../../../en/platform/corda/4.9/open-source/key-concepts-vault.md).
+Read more about the vault in [Vault](../../../../../../../en/platform/corda/4.9/community/key-concepts-vault.md).
 
 Note that the vault tables are guaranteed to remain backwards compatible and are safe to be used directly by third party applications.
 

--- a/content/en/platform/corda/4.9/enterprise/node/operating/querying-flow-data.md
+++ b/content/en/platform/corda/4.9/enterprise/node/operating/querying-flow-data.md
@@ -50,7 +50,7 @@ To view the full code sample, see [NodeFlowStatusRpcOps.kt](../../resources/exte
 The Multi RPC Client version must be aligned with the node version, meaning that both must be running the same Corda Enterprise version.
 {{< /warning >}}
 
-For details of how to build a Multi RPC Client, see [Building a Multi RPC Client](../../../../../../../en/platform/corda/4.9/enterprise/node/operating/clientrpc.html#building-the-multi-rpc-client). See also [MultiRPCClient](../../../../../../../en/api-ref/corda/4.9/open-source/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) in the API documentation.
+For details of how to build a Multi RPC Client, see [Building a Multi RPC Client](../../../../../../../en/platform/corda/4.9/enterprise/node/operating/clientrpc.html#building-the-multi-rpc-client). See also [MultiRPCClient](../../../../../../../en/api-ref/corda/4.9/community/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) in the API documentation.
 
 ### Specifying the query criteria
 

--- a/content/en/platform/corda/4.9/enterprise/node/setup/corda-configuration-fields.md
+++ b/content/en/platform/corda/4.9/enterprise/node/setup/corda-configuration-fields.md
@@ -940,6 +940,6 @@ Internal option.
   This option is disabled by default and is independent from `devMode`.
   {{< /note >}}
 
-  For full details, see [Automatic detection of unrestorable checkpoints](../../../../../../../en/platform/corda/4.9/open-source/checkpoint-tooling.html#automatic-detection-of-unrestorable-checkpoints).
+  For full details, see [Automatic detection of unrestorable checkpoints](../../../../../../../en/platform/corda/4.9/community/checkpoint-tooling.html#automatic-detection-of-unrestorable-checkpoints).
 
   *Default:* not defined

--- a/content/en/platform/corda/4.9/enterprise/operations/deployment/deployment-kubernetes.md
+++ b/content/en/platform/corda/4.9/enterprise/operations/deployment/deployment-kubernetes.md
@@ -286,7 +286,7 @@ kubectl get pods -o wide
 You will find the truststore password in the `signer/files/pki.conf`, where the default value used in this Helm chart is `trust-store-password`.
 
 {{< note >}} For more details about joining a CENM network, see:
-[Joining an existing compatibility zone](../../../../../../../en/platform/corda/4.9/open-source/joining-a-compatibility-zone.md).
+[Joining an existing compatibility zone](../../../../../../../en/platform/corda/4.9/community/joining-a-compatibility-zone.md).
 {{< /note >}}
 
 ### Display logs

--- a/content/en/platform/corda/4.9/enterprise/oracles.md
+++ b/content/en/platform/corda/4.9/enterprise/oracles.md
@@ -327,7 +327,7 @@ class FixSignFlow(val tx: TransactionBuilder, val oracle: Party,
 [RatesFixFlow.kt](https://github.com/corda/corda/blob/release/os/4.9/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/flows/RatesFixFlow.kt)
 
 You’ll note that the `FixSignFlow` requires a `FilterTransaction` instance which includes only `Fix` commands.
-You can find a further explanation of this in [Oracles](../../../../../en/platform/corda/4.9/open-source/key-concepts-oracles.md). Below you will see how to build such a
+You can find a further explanation of this in [Oracles](../../../../../en/platform/corda/4.9/community/key-concepts-oracles.md). Below you will see how to build such a
 transaction with hidden fields.
 
 


### PR DESCRIPTION
A fix where links to Open Source Edition docs broke when it was renamed Community Edition.