### PR TITLE
DOC-4367 - Added missing info on platform version 11 for 4.9

### DIFF
--- a/content/en/platform/corda/4.9/community/app-upgrade-notes.md
+++ b/content/en/platform/corda/4.9/community/app-upgrade-notes.md
@@ -43,6 +43,7 @@ If you are using them you should re-namespace them to a package namespace you co
 {{< table >}}
 | Corda release  | Platform version |
 | :------------- | :------------- |
+| 4.9 | 11 |
 | 4.8 | 10 |
 | 4.7 | 9 |
 | 4.6 | 8 |
@@ -54,6 +55,10 @@ If you are using them you should re-namespace them to a package namespace you co
 | 4.0 | 4 |
 | 3.3 | 3 |
 {{< /table >}}
+
+## Upgrading apps to Platform Version 11
+
+No manual upgrade steps are required.
 
 ## Upgrading apps to Platform Version 10
 

--- a/content/en/platform/corda/4.9/community/versioning.md
+++ b/content/en/platform/corda/4.9/community/versioning.md
@@ -80,6 +80,7 @@ can be disabled.
 {{< table >}}
 | Corda release  | Platform version |
 | :------------- | :------------- |
+| 4.9 | 11 |
 | 4.8 | 10 |
 | 4.7 | 9 |
 | 4.6 | 8 |

--- a/content/en/platform/corda/4.9/enterprise/app-upgrade-notes.md
+++ b/content/en/platform/corda/4.9/enterprise/app-upgrade-notes.md
@@ -49,6 +49,10 @@ If you do use them, re-namespace them to a package namespace you control and sig
 | 3.3 | 3 |
 {{< /table >}}
 
+## Upgrade CorDapps to platform version 11
+
+You don't need to perform a manual upgrade for this platform version.
+
 ## Upgrade CorDapps to platform version 10
 
 You don't need to perform a manual upgrade for this platform version.


### PR DESCRIPTION
Confirmed with @Adel El-Beik that no manual instructions are required for platform 11 (or indeed for platform 12, 4.10).