### PR TITLE
banner-change

### DIFF
--- a/themes/doks/layouts/partials/header/header.html
+++ b/themes/doks/layouts/partials/header/header.html
@@ -1,8 +1,10 @@
 <header>
   <!-- Banner for alerts. Just move closing comment mark to the end of this sentence and update text.    -->
     <p style="color:#FFFFFF; background-color: #ec1d25; text-align: center; margin-bottom:0rem;">
-        <b><a style ="color:#FFFFFF; text-decoration: underline;" href="https://docs.r3.com/en/platform/corda/5.0-dev-preview-2.html">Corda 5 Developer Preview 2</a></b> is now available.
+        <b><a style ="color:#FFFFFF; text-decoration: underline;" href="https://docs.r3.com/en/platform/corda/4.5/enterprise.html">Corda Enterprise v4.5</a></b> and </b><b><a style ="color:#FFFFFF; text-decoration: underline;" href="https://docs.r3.com/en/platform/corda/4.6/enterprise.html">Corda Enterprise v4.6</a></b> documentation will be archived on 31/01/2023.
     </p>
+
+    <!-- <b><a style ="color:#FFFFFF; text-decoration: underline;" href="https://docs.r3.com/en/platform/corda/5.0-dev-preview-2.html">Corda 5 Developer Preview 2</a></b> is now available. -->
 
   <div class="navbar  navbar-dark">
     <div class="container-fluid">


### PR DESCRIPTION
Banner updated from DP2 announcement to C4.5-C4.6 archiving announcement.

<img width="1041" alt="image" src="https://user-images.githubusercontent.com/112863914/210862685-a786e2c4-28a1-4625-87db-50d98a8dfffd.png">
