### PR TITLE
end-of-life-signposts

### DIFF
--- a/content/en/release-notes/_index.md
+++ b/content/en/release-notes/_index.md
@@ -31,6 +31,11 @@ Find here the release notes for the latest versions of Corda Community (formerly
 ## Log4j patches
 Find [all patches](../../en/release-notes/log4j-patches.md) addressing the December 2021 Log4j vulnerability.
 
-## Archived release documentation of older, non-supported Corda releases
+## Archived documentation for older non-supported Corda releases
 
-All documentation for older historic releases of Corda open source (versions 1.0, 2.0, and 3.0 to 3.3) and Corda Enterprise (versions 3.0 to 3.4), including release notes, is accessible from the [archived docs](https://github.com/corda/corda-docs-portal/tree/main/archived-docs) directory in the [corda/corda-docs-portal](https://github.com/corda/corda-docs-portal) repository.
+Documentation for non-supported releases of Corda Open Source, Corda Enterprise, and CENM, is accessible from the [archived docs](https://github.com/corda/corda-docs-portal/tree/main/archived-docs) directory of the [corda/corda-docs-portal](https://github.com/corda/corda-docs-portal) repository. 
+
+{{< note >}}
+For information about our documentation end of life schedule and links to each archived version, refer to the [Corda end of life schedule](../../en/release-notes/eol.md).
+{{< /note >}}
+

--- a/content/en/release-notes/eol.md
+++ b/content/en/release-notes/eol.md
@@ -4,26 +4,22 @@ menu:
   releases:
     name: Corda end of life schedule
     identifier: corda-end-of-life-schedule
-title: Corda end of support schedule
+title: Corda end of life schedule
 weight: 70
 ---
 
-Use the following table to track the end of life for each version of Corda. Each version of Corda Enterprise and Corda Community Edition has support available from R3 for a fixed period. After this period has ended, these versions will no longer be supported by R3. You should always aim to upgrade to the latest version of Corda whenever possible.
+Use the following table to track the end of life schedule for each version of Corda. Each version of Corda Enterprise, Corda Community Edition, and CENM has support available from R3 for a fixed period. After this period has ended, these versions are no longer supported by R3 and associated documentation is archived. You should always aim to upgrade to the latest version of Corda whenever possible.
 
 Definitions:
 
 * **End of maintenance**: This release will no longer receive functional patches after the date shown.
 * **End of security**: This release will no longer be eligible for security patches after the date shown.
-* **End of support**: Support, provided by R3, is not available after this date.
-
-
-All dates refer to the end of the month indicated.
+* **End of support**: Support provided by R3 is no longer available after this date.
 
 {{< table >}}
 
 | Corda version | Date of release    | End of Maintenance | End of security | End of support |
 | :------------- | :------------- | :-------------- | :------------ | :------------ |
-| Corda Enterprise 4.4   | 03/2020 | 03/2022 | 03/2023 | 03/2022 |
 | Corda Enterprise 4.5   | 06/2020 | 06/2022 | 06/2023 | 06/2022 |
 | Corda Enterprise 4.6   | 09/2020 | 09/2022 | 09/2023 | 09/2022 |
 | Corda Enterprise 4.7   | 12/2020 | 12/2022 | 12/2023 | 12/2023 |
@@ -34,5 +30,41 @@ All dates refer to the end of the month indicated.
 {{< /table >}}
 
 {{< note >}}
-Versions that precede Corda Enterprise 4.4 have already passed their end of support date.
+All dates refer to the end of the month indicated.
 {{< /note >}}
+
+## Index of archived documentation
+
+Documentation for non-supported releases of Corda Open Source, Corda Enterprise, and CENM, is accessible from the [archived docs](https://github.com/corda/corda-docs-portal/tree/main/archived-docs) directory of the [corda/corda-docs-portal](https://github.com/corda/corda-docs-portal) repository. The following is a list of direct links for various archived versions:
+
+{{< table >}}
+
+| Corda version          | Link to archived docs                                                 | 
+| :--------------------- | :-------------- | 
+| Corda 5 Dev Preview 1  | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/5.0-dev-preview-1) | 
+| Corda Enterprise 3.0   | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-enterprise/3.0) | 
+| Corda Enterprise 3.1   | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-enterprise/3.1) | 
+| Corda Enterprise 3.2   | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-enterprise/3.2) | 
+| Corda Enterprise 3.3   | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-enterprise/3.3) | 
+| Corda Enterprise 4.0   | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-enterprise/4.0) | 
+| Corda Enterprise 4.1   | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-enterprise/4.1) | 
+| Corda Enterprise 4.2   | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-enterprise/4.2) | 
+| Corda Enterprise 4.3   | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-enterprise/4.3) | 
+| Corda Enterprise 4.4   | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-enterprise/4.4) | 
+| Corda Open Source 1.0  | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-os/1.0) | 
+| Corda Open Source 2.0  | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-os/2.0) | 
+| Corda Open Source 3.0  | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-os/3.0) | 
+| Corda Open Source 3.1  | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-os/3.1) | 
+| Corda Open Source 3.2  | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-os/3.2) | 
+| Corda Open Source 3.3  | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-os/3.3) | 
+| Corda Open Source 3.4  | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-os/3.4) | 
+| Corda Open Source 4.0  | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-os/4.0) | 
+| Corda Open Source 4.1  | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-os/4.1) |  
+| Corda Open Source 4.3  | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-os/4.3) | 
+| Corda Open Source 4.4  | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-os/4.4) | 
+| Corda Open Source 4.5  | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-os/4.5) | 
+| Corda Open Source 4.6  | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-os/4.6) | 
+| Corda Open Source 4.7  | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-os/4.7) | 
+| Corda Open Source 4.8  | [Archive Link](https://github.com/corda/corda-docs-portal/tree/main/archived-docs/corda-os/4.8) | 
+
+{{< /table >}}


### PR DESCRIPTION
1. The EoL paras on Corda index page was updated to read better and link through to main EoL page.
2. The EoL page was updated, with the main focus on a new table of links through to each archived version. Better and more obvious signposting was requested by dev evangelists - hence the table.