### PR TITLE
DOC-4524 - updated Enterprise and Community release notes with dependency info from Chris C (email 10 Jan)

### DIFF
--- a/content/en/platform/corda/4.10/community/release-notes.md
+++ b/content/en/platform/corda/4.10/community/release-notes.md
@@ -59,17 +59,18 @@ In this release:
 * Previously, Archive Service commands did not write messages to the log files unless an error or issue occurred. An update now means that messages are also written when commands are run successfully. For more information, refer to [Archive Service Command-Line Interface (CLI)](..\..\..\..\tools\archiving-service\archiving-cli.md)
 
 * The opentelemetry tracing signal is now supported in flows across nodes.
+  
+### Database Schema Changes
 
-* Previously, when configured to use confidential identities and the Securosys PrimusX HSM, it was possible for Corda to fail to generate a wrapped key-pair for a new confidential identity. This would cause a temporary key-pair to be leaked, consuming resource in the HSM. This issue occurred when:
+There are no database changes between 4.9 and 4.10.
 
-  * The Securosys HSM was configured in a master-clone cluster.
 
-  * The master HSM had failed and Corda had failed-over to use the clone HSM.
+### Third party component upgrades
 
-  * There was an attempt to create a transaction using confidential identities.
+The following table lists the dependency version changes between 4.9.5 and 4.10 Community Editions:
 
-  The issue is now resolved. When generating a wrapped key-pair, the temporary key-pair is not persisted in the HSM and thus cannot be leaked.
-
-  On applying this update it is recommended that the PrimusX JCE should be upgraded to version 2.3.4 or later for optimum performance of the HSM. If the JCE is not updated, then no keys are leaked but they are temporarily created in the HSM and are then garbage-collected within 24 hours.
-
-  There is no need to upgrade the HSM firmware version for this update, but it is recommended to keep the firmware up to date as a matter of course. Currently the latest firmware version is 2.8.50.
+| Dependency           | Name           | Version 4.9.5 Community | Version 4.10 Community |
+|----------------------|----------------|-------------------------|------------------------|
+| com.squareup.okhttp3 | OKHttp         | 3.14.2                  | 3.14.9                 |
+| org.bouncycastle	   | Bouncy Castle  | 1.68                    | 1.70                   |
+| io.opentelemetry	   | Open Telemetry | -                       | 1.20.1                 |

--- a/content/en/platform/corda/4.10/enterprise/release-notes-enterprise.md
+++ b/content/en/platform/corda/4.10/enterprise/release-notes-enterprise.md
@@ -65,24 +65,18 @@ In this release:
 
 * The opentelemetry tracing signal is now supported in flows across nodes.
 
-* Previously, when configured to use confidential identities and the Securosys PrimusX HSM, it was possible for Corda to fail to generate a wrapped key-pair for a new confidential identity. This would cause a temporary key-pair to be leaked, consuming resource in the HSM. This issue occurred when:
-
-  * The Securosys HSM was configured in a master-clone cluster.
-
-  * The master HSM had failed and Corda had failed-over to use the clone HSM.
-
-  * There was an attempt to create a transaction using confidential identities.
-
-  The issue is now resolved. When generating a wrapped key-pair, the temporary key-pair is not persisted in the HSM and thus cannot be leaked.
-
-  On applying this update it is recommended that the PrimusX JCE should be upgraded to version 2.3.4 or later for optimum performance of the HSM. If the JCE is not updated, then no keys are leaked but they are temporarily created in the HSM and are then garbage-collected within 24 hours.
-
-  There is no need to upgrade the HSM firmware version for this update, but it is recommended to keep the firmware up to date as a matter of course. Currently the latest firmware version is 2.8.50.
-
 ### Database Schema Changes
 
-
-
+There are no database changes between 4.9 and 4.10.
 
 ### Third party component upgrades
 
+The following table lists the dependency version changes between 4.9.5 and 4.10 Enterprise Editions:
+
+| Dependency                         | Name                | Version 4.9.5 Enterprise | Version 4.10 Enterprise|
+|------------------------------------|---------------------|--------------------------|------------------------|
+| com.squareup.okhttp3               | OKHttp              | 3.14.2                   | 3.14.9                 |
+| org.bouncycastle                   | Bouncy Castle       | 1.68                     | 1.70                   |
+| io.opentelemetry                   | Open Telemetry      | -                        | 1.20.1                 |
+| org.apache.commons:commons-text    | Apache Commons-Text | 1.9                      | 1.10.0                 |
+| org.apache.shiro                   | Apache Shiro        | 1.9.1                    | 1.10.0                 |


### PR DESCRIPTION
DOC-4524 - updated Enterprise and Community release notes with dependency info from Chris C (email 10 Jan)

Additionally, removed a release note entry accidentally added too early - https://r3-cev.atlassian.net/browse/ENT-8831. This actually belongs to 4.10.1, a later patch release.