### PR TITLE
ENT-8817 - Non-reentrant ConcurrentHashMap.compute() causes deadlock - added release notes entry

### DIFF
--- a/content/en/platform/corda/4.10/community/release-notes.md
+++ b/content/en/platform/corda/4.10/community/release-notes.md
@@ -59,11 +59,12 @@ In this release:
 * Previously, Archive Service commands did not write messages to the log files unless an error or issue occurred. An update now means that messages are also written when commands are run successfully. For more information, refer to [Archive Service Command-Line Interface (CLI)](..\..\..\..\tools\archiving-service\archiving-cli.md)
 
 * The opentelemetry tracing signal is now supported in flows across nodes.
+
+* A rare condition was found when database transactions are rolled back under heavy load that caused flow state machine threads to stop processing flows, leading to eventual node lockup in certain circumstances.  This fix prevents this from happening.
   
 ### Database Schema Changes
 
 There are no database changes between 4.9 and 4.10.
-
 
 ### Third party component upgrades
 

--- a/content/en/platform/corda/4.10/community/release-notes.md
+++ b/content/en/platform/corda/4.10/community/release-notes.md
@@ -60,7 +60,7 @@ In this release:
 
 * The opentelemetry tracing signal is now supported in flows across nodes.
 
-* A rare condition was found when database transactions are rolled back under heavy load that caused flow state machine threads to stop processing flows, leading to eventual node lockup in certain circumstances.  This fix prevents this from happening.
+* A rare condition was found when database transactions were rolled back under heavy load that caused flow state machine threads to stop processing flows. This resulted in eventual node lockup in certain circumstances. This fix prevents this from happening.
   
 ### Database Schema Changes
 

--- a/content/en/platform/corda/4.10/enterprise/release-notes-enterprise.md
+++ b/content/en/platform/corda/4.10/enterprise/release-notes-enterprise.md
@@ -65,6 +65,8 @@ In this release:
 
 * The opentelemetry tracing signal is now supported in flows across nodes.
 
+* A rare condition was found when database transactions are rolled back under heavy load that caused flow state machine threads to stop processing flows, leading to eventual node lockup in certain circumstances.  This fix prevents this from happening.
+
 ### Database Schema Changes
 
 There are no database changes between 4.9 and 4.10.

--- a/content/en/platform/corda/4.10/enterprise/release-notes-enterprise.md
+++ b/content/en/platform/corda/4.10/enterprise/release-notes-enterprise.md
@@ -65,7 +65,7 @@ In this release:
 
 * The opentelemetry tracing signal is now supported in flows across nodes.
 
-* A rare condition was found when database transactions are rolled back under heavy load that caused flow state machine threads to stop processing flows, leading to eventual node lockup in certain circumstances.  This fix prevents this from happening.
+* A rare condition was found when database transactions were rolled back under heavy load that caused flow state machine threads to stop processing flows. This resulted in eventual node lockup in certain circumstances. This fix prevents this from happening.
 
 ### Database Schema Changes
 


### PR DESCRIPTION
ENT-8817 - Non-reentrant ConcurrentHashMap.compute() causes deadlock - added release notes entry:

"A rare condition was found when database transactions are rolled back under heavy load that caused flow state machine threads to stop processing flows, leading to eventual node lockup in certain circumstances.  This fix prevents this from happening."