### PR TITLE
Add ENT-8814,  ENT-8811 and ENT-8796 to release notes

### DIFF
--- a/content/en/platform/corda/4.10/community/release-notes.md
+++ b/content/en/platform/corda/4.10/community/release-notes.md
@@ -59,6 +59,12 @@ In this release:
 * Previously, Archive Service commands did not write messages to the log files unless an error or issue occurred. An update now means that messages are also written when commands are run successfully. For more information, refer to [Archive Service Command-Line Interface (CLI)](..\..\..\..\tools\archiving-service\archiving-cli.md)
 
 * The opentelemetry tracing signal is now supported in flows across nodes.
+
+* Previously, a memory leak in the transaction cache occurred due to weight of in-flight entries being undervalued. Improvements have been made to prevent in-flight entry weights from being undervalued and, because they are now estimated more correctly, this results in a large decrease in the total size of cached entities.
+
+* Flow draining mode no longer acknowledges P2P in-flight messages that have not yet been committed to the database. Previously, flow draining mode acknowledged all in-flight messages as duplicate.
+
+* Previously, the attachment class loader was being closed too early if it is evicted from the cache. Now, closing of attachment class loaders is delayed until all SerializationContext that refer to them (from BasicVerifier) have gone out of scope.
   
 ### Database Schema Changes
 

--- a/content/en/platform/corda/4.10/enterprise/release-notes-enterprise.md
+++ b/content/en/platform/corda/4.10/enterprise/release-notes-enterprise.md
@@ -65,6 +65,12 @@ In this release:
 
 * The opentelemetry tracing signal is now supported in flows across nodes.
 
+* Previously, a memory leak in the transaction cache occurred due to weight of in-flight entries being undervalued. Improvements have been made to prevent in-flight entry weights from being undervalued and, because they are now estimated more correctly, this results in a large decrease in the total size of cached entities.
+
+* Flow draining mode no longer acknowledges P2P in-flight messages that have not yet been committed to the database. Previously, flow draining mode acknowledged all in-flight messages as duplicate.
+
+* Previously, the attachment class loader was being closed too early if it is evicted from the cache. Now, closing of attachment class loaders is delayed until all SerializationContext that refer to them (from BasicVerifier) have gone out of scope.
+
 ### Database Schema Changes
 
 There are no database changes between 4.9 and 4.10.


### PR DESCRIPTION
ENT-8814: Transaction cache has memory leak

* Previously, a memory leak in the transaction cache occurred due to weight of in-flight entries being undervalued. Improvements have been made to prevent in-flight entry weights from being undervalued and, because they are now estimated more correctly, this results in a large decrease in the total size of cached entities.

(text from 4.9.5)

ENT-8811: Flow draining mode is broken and can acknowledge all the P2P messages in Artemis

* Flow draining mode no longer acknowledges P2P in-flight messages that have not yet been committed to the database. Previously, flow draining mode acknowledged all in-flight messages as duplicate.

(text from 4.9.4)

ENT-8796: Delay closing of attachment class loaders until all SerializationContext that refer to them (from BasicVerifier) have gone out of scope.

Previously, the attachment class loader was being closed too early if it is evicted from the cache. Now, closing of attachment class loaders is delayed until all SerializationContext that refer to them (from BasicVerifier) have gone out of scope.