### PR TITLE
DOC-4532 - updated pages to show 4.10 links. Also fix to menu to put Enterprise 4.10 in right order

### DIFF
--- a/content/en/platform/_index.md
+++ b/content/en/platform/_index.md
@@ -7,6 +7,13 @@ section_menu: homepage
 ## Corda
 
 * [Corda 5 Developer Preview](en/platform/corda/5.0-dev-preview-2.html)
+* 4.10
+  * Community Edition
+    * [Main documentation](en/platform/corda/4.10/community.html)
+    * [Release notes](en/platform/corda/4.10/community/release-notes.html)
+  * Enterprise
+    * [Main documentation](en/platform/corda/4.10/enterprise.html)
+    * [Release notes](en/platform/corda/4.10/enterprise/release-notes-enterprise.html)
 * 4.9
   * Community Edition (formerly Open Source)
     * [Main documentation](en/platform/corda/4.9/community.html)

--- a/content/en/platform/corda/4.10/enterprise/_index.md
+++ b/content/en/platform/corda/4.10/enterprise/_index.md
@@ -2,7 +2,7 @@
 date: '2020-04-07T12:00:00Z'
 menu:
   versions:
-    weight: -655
+    weight: -648
   corda-enterprise-4-10:
     weight: 1
     name: Corda Enterprise Edition 4.10

--- a/content/en/platform/corda/_index.md
+++ b/content/en/platform/corda/_index.md
@@ -32,8 +32,8 @@ The Corda platform documentation covers the following versions of the Corda plat
 
 ### Corda 4 Community Edition (Formerly Open Source)
 
-* [Corda 4.10 Community Edition](../platform/corda/4.10/open-source.html)
-* [Corda 4.9 Community Edition](../platform/corda/4.9/open-source.html)
+* [Corda 4.10 Community Edition](../platform/corda/4.10/community.html)
+* [Corda 4.9 Community Edition](../platform/corda/4.9/community.html)
 
 ### Corda 4 Enterprise
 


### PR DESCRIPTION
DOC-4532 - updated pages to show 4.10 links. Also fix to menu to put Enterprise 4.10 in right order