### PR TITLE
DOC-4542  - removed 'Improved cryptoservice exception behaviour' head…

### DIFF
--- a/content/en/platform/corda/4.10/enterprise/release-notes-enterprise.md
+++ b/content/en/platform/corda/4.10/enterprise/release-notes-enterprise.md
@@ -42,8 +42,6 @@ Previously, if a node failed to open an AMQP connection to a peer node because t
 
 A new node configuration option, `cryptoServiceFlowRetryCount`, has been introduced.
 
-### Improved cryptoservice exception behavior
-
 Previously, flows that suffered a `CryptoServiceException` were admitted to the flow hospital for processing. The flow was retried a maximum of two times, and if it still failed then the exception was propagated back to the code that invoked the flow and the flow was failed.
 
 Now, *cryptoServiceFlowRetryCount* can be used to override the above default actions for when a CryptoServiceException exception has been thrown due to a timeout with the crypto service. Other causes of `CryptoServiceException` are unaffected by this update.


### PR DESCRIPTION
Removed 'Improved cryptoservice exception behaviour' heading so the previous section and next in Enterprise release notes merge into one.