### PR TITLE
Doc 4543 - Update pages for 4.10

### DIFF
--- a/content/en/api-ref/_index.md
+++ b/content/en/api-ref/_index.md
@@ -22,7 +22,7 @@ See the [Corda 5 Developer Preview API reference](../../en/api-ref/corda/5.0-dev
 
 ## Corda 4 API reference
 
-See the [Corda 4 API reference](../../en/api-ref/api-ref-corda-4.md) page to access the API reference documentation for all API modules publicly exposed in the Corda 4 releases, including Corda Open Source 4.0 to 4.8, Corda Community Edition 4.9, Corda Enterprise 4.0 to 4.9, and Corda Enterprise Network Manager (CENM) 1.0 to 1.5.
+See the [Corda 4 API reference](../../en/api-ref/api-ref-corda-4.md) page to access the API reference documentation for all API modules publicly exposed in the Corda 4 releases, including Corda Community Edition 4.10, Corda Enterprise 4.5 to 4.10, and Corda Enterprise Network Manager (CENM) 1.0 to 1.5.
 
 ## Older Corda API reference
 

--- a/content/en/api-ref/api-ref-corda-4.md
+++ b/content/en/api-ref/api-ref-corda-4.md
@@ -11,13 +11,14 @@ title: Corda 4 API reference
 
 # Corda 4 API reference
 
-This page provides links to the API reference documentation for all API modules publicly exposed in the Corda 4 releases, including Corda open source 4.0 to 4.8, Corda Enterprise 4.0 to 4.8, and Corda Enterprise Network Manager (CENM) 1.0 to 1.5.
+This page provides links to the API reference documentation for all API modules publicly exposed in the Corda 4 releases, including Corda Community 4.10, Corda Enterprise 4.5 to 4.10, and Corda Enterprise Network Manager (CENM) 1.0 to 1.5.
 
 ## Corda Enterprise 4.x API reference
 
 {{< table >}}
 |Corda Enterprise version|Javadoc API reference|Kotlin doc API reference|
 |:----|:----|:----|
+|4.10|<a href="../../../en/api-ref/corda/4.10/enterprise/javadoc/index.html" target="_blank">Javadoc</a>|<a href="../../../en/api-ref/corda/4.10/enterprise/kotlin/corda/index.html" target="_blank">Kotlin</a>|
 |4.9|<a href="../../../en/api-ref/corda/4.9/enterprise/javadoc/index.html" target="_blank">Javadoc</a>|<a href="../../../en/api-ref/corda/4.9/enterprise/kotlin/corda/index.html" target="_blank">Kotlin</a>|
 |4.8|<a href="../../../en/api-ref/corda/4.8/enterprise/javadoc/index.html" target="_blank">Javadoc</a>|<a href="../../../en/api-ref/corda/4.8/enterprise/kotlin/corda/index.html" target="_blank">Kotlin</a>|
 |4.7|<a href="../../../en/api-ref/corda/4.7/enterprise/javadoc/index.html" target="_blank">Javadoc</a>|<a href="../../../en/api-ref/corda/4.7/enterprise/kotlin/corda/index.html" target="_blank">Kotlin</a>|
@@ -31,30 +32,13 @@ This page provides links to the API reference documentation for all API modules 
 
 {{< /table >}}
 
-## Corda Community Edition 4.x API reference
+## Corda Community Edition 4.10 API reference
 
 {{< table >}}
 
 |Corda Community Edition version|Javadoc API reference|Kotlin doc API reference|
 |:----|:----|:----|
-|4.9|<a href="../../../en/api-ref/corda/4.9/community/javadoc/index.html" target="_blank">Javadoc</a>|<a href="../../../en/api-ref/corda/4.9/community/kotlin/corda/index.html" target="_blank">Kotlin</a>|
-
-{{< /table >}}
-
-## Corda open source 4.x API reference
-
-{{< table >}}
-
-|Corda open source version|Javadoc API reference|Kotlin doc API reference|
-|:----|:----|:----|
-|4.8|<a href="../../../en/api-ref/corda/4.8/open-source/javadoc/index.html" target="_blank">Javadoc</a>|<a href="../../../en/api-ref/corda/4.8/open-source/kotlin/corda/index.html" target="_blank">Kotlin</a>|
-|4.7|<a href="../../../en/api-ref/corda/4.7/open-source/javadoc/index.html" target="_blank">Javadoc</a>|<a href="../../../en/api-ref/corda/4.7/open-source/kotlin/corda/index.html" target="_blank">Kotlin</a>|
-|4.6|<a href="../../../en/api-ref/corda/4.6/open-source/javadoc/index.html" target="_blank">Javadoc</a>|<a href="../../../en/api-ref/corda/4.6/open-source/kotlin/corda/index.html" target="_blank">Kotlin</a>|
-|4.5|<a href="../../../en/api-ref/corda/4.5/open-source/javadoc/index.html" target="_blank">Javadoc</a>|<a href="../../../en/api-ref/corda/4.5/open-source/kotlin/corda/index.html" target="_blank">Kotlin</a>|
-|4.4|<a href="../../../en/api-ref/corda/4.4/open-source/javadoc/index.html" target="_blank">Javadoc</a>|<a href="../../../en/api-ref/corda/4.4/open-source/kotlin/corda/index.html" target="_blank">Kotlin</a>|
-|4.3|<a href="../../../en/api-ref/corda/4.3/open-source/javadoc/index.html" target="_blank">Javadoc</a>|<a href="../../../en/api-ref/corda/4.3/open-source/kotlin/corda/index.html" target="_blank">Kotlin</a>|
-|4.1|<a href="../../../en/api-ref/corda/4.1/open-source/javadoc/index.html" target="_blank">Javadoc</a>|<a href="../../../en/api-ref/corda/4.1/open-source/kotlin/corda/index.html" target="_blank">Kotlin</a>|
-|4.0|<a href="../../../en/api-ref/corda/4.0/open-source/javadoc/index.html" target="_blank">Javadoc</a>|<a href="../../../en/api-ref/corda/4.0/open-source/kotlin/corda/index.html" target="_blank">Kotlin</a>|
+|4.9|<a href="../../../en/api-ref/corda/4.10/community/javadoc/index.html" target="_blank">Javadoc</a>|<a href="../../../en/api-ref/corda/4.10/community/kotlin/corda/index.html" target="_blank">Kotlin</a>|
 
 {{< /table >}}
 

--- a/themes/doks/layouts/index.html
+++ b/themes/doks/layouts/index.html
@@ -141,8 +141,8 @@
             <h3 class="card-title">Corda 4</h3>
             <p>Everything you need to know about the Corda 4 platform series - read the comprehensive documentation sets for:</p>
             <ul>
-              <li style="text-align: left;"><a href="en/platform/corda/4.10/enterprise.html">Corda Enterprise Edition 4.10</a></li>
-              <li style="text-align: left;"><a href="en/platform/corda/4.10/community.html">Corda Community Edition 4.10</a></li>
+              <li style="text-align: left;"><a href="en/platform/corda/4.10/enterprise.html">Corda Enterprise 4.10</a></li>
+              <li style="text-align: left;"><a href="en/platform/corda/4.10/community.html">Corda Community 4.10</a></li>
               <li style="text-align: left;"><a href="en/platform/corda/1.5/cenm.html">CENM 1.5</a></li>
             </ul>
           </div>

--- a/themes/doks/layouts/index.html
+++ b/themes/doks/layouts/index.html
@@ -141,8 +141,8 @@
             <h3 class="card-title">Corda 4</h3>
             <p>Everything you need to know about the Corda 4 platform series - read the comprehensive documentation sets for:</p>
             <ul>
-              <li style="text-align: left;"><a href="en/platform/corda/4.9/enterprise.html">Corda Enterprise 4.9</a></li>
-              <li style="text-align: left;"><a href="en/platform/corda/4.8/open-source.html">Corda OS 4.8</a></li>
+              <li style="text-align: left;"><a href="en/platform/corda/4.10/enterprise.html">Corda Enterprise Edition 4.10</a></li>
+              <li style="text-align: left;"><a href="en/platform/corda/4.10/community.html">Corda Community Edition 4.10</a></li>
               <li style="text-align: left;"><a href="en/platform/corda/1.5/cenm.html">CENM 1.5</a></li>
             </ul>
           </div>


### PR DESCRIPTION
- the root page the “Corda 4” box-out links are now for 4.10

- the [API ref page](https://paul.preview.docs.r3.com/en/api-ref.html) says now only includes Community 10 and Enterprise 4.5 to 4.10

- The [Corda 4 API ref page](https://paul.preview.docs.r3.com/en/api-ref/api-ref-corda-4.html) now has 4.10 links