### PR TITLE
open REST API in new tab

### DIFF
--- a/content/en/platform/corda/5.0-beta/_index.md
+++ b/content/en/platform/corda/5.0-beta/_index.md
@@ -77,7 +77,7 @@ menu:
   <div class="card h-100">
     <div class="card-body">
       <h3 class="card-title">
-      <a href="../../../../../../en/platform/corda/5.0-beta/rest-api/C5_OpenAPI.html">
+      <a href="../../../../../../en/platform/corda/5.0-beta/rest-api/C5_OpenAPI.html" target="_blank">
           <img src="5.0-beta/icons/API.png" alt="REST API" style="padding: 1rem; border: 0;" class="light-only" height="124">
           <img src="5.0-beta/icons/API.png" alt="REST API" style="background: #202020; padding: 1rem; border: 0;" class="dark-only" height="124"></br>
         <span>REST API Reference</span></h3></a>


### PR DESCRIPTION
Small change to make the REST API ref link on the homepage open in a new tab/window as this page is outside the main doc portal navigation.