### PR TITLE
Update script-header.html

### DIFF
--- a/themes/doks/layouts/partials/head/script-header.html
+++ b/themes/doks/layouts/partials/head/script-header.html
@@ -8,7 +8,7 @@
 
     {{ if eq .IsHome true }}
       window.facetFilters = [
-        ['project:corda', 'project:releases', 'project:get-started', 'project:tutorials', 'project:samples', 'project:api-ref', 'project:apps', 'project:tools', 'project:announcements', 'project:conclave', 'version:Community Edition 4.10', 'version:Enterprise 4.10', 'version:CENM 1.5', 'version:Corda 5 Developer Preview 2', 'version:Corda 5.0 Beta 1'],
+        ['project:get-started', 'project:tutorials', 'project:samples', 'project:tools', 'project:announcements', 'version:Community Edition 4.10', 'version:Enterprise 4.10', 'version:CENM 1.5', 'version:Corda 5 Developer Preview 2', 'version:Corda 5.0 Beta 1'],
         'language:en'
       ];
 


### PR DESCRIPTION
A change was made previously to filter searches from the homepage to match a specified project OR one of the latest specified versions. (Previously, content that only appeared under the "tools" project, for example, and was not version specific, was not included in searches.) However, because we were then always including "corda" project files, versions other than the latest specified versions were also included. I have now removed the "corda" project and some other unnecessary projects.