### PR TITLE
NOTICK: upgrade s3deploy to the newest version 2.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN mkdir -p /tmp/hugo && cd /tmp/hugo && \
 ARG S3DEPLOY_VERSION
 
 RUN mkdir -p /tmp/s3deploy && cd /tmp/s3deploy && \
-    curl -L https://github.com/bep/s3deploy/releases/download/v${S3DEPLOY_VERSION}/s3deploy_${S3DEPLOY_VERSION}_Linux-64bit.tar.gz | tar -xz && \
+    curl -L https://github.com/bep/s3deploy/releases/download/v${S3DEPLOY_VERSION}/s3deploy_${S3DEPLOY_VERSION}_linux-"$(dpkg --print-architecture)".tar.gz | tar -xz && \
     install -o root -g root -m 755 -t /usr/local/bin s3deploy && \
     rm -rf /tmp/s3deploy
 

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ ROOT_DIR          := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 DOCKER             = docker
 DOCKER_RUN         = $(DOCKER) run --rm --volume $(ROOT_DIR):/src $(DOCKER_BUILD_ARGS)
 HUGO_VERSION       = 0.74.3
-S3DEPLOY_VERSION   = 2.3.5
+S3DEPLOY_VERSION   = 2.9.0
 REGISTRY           = library
 CADDY_VERSION      = 2.4.3
 MUFFET_VERSION     = 2.4.2
@@ -78,6 +78,7 @@ publish: prod-hugo-build ## Build site, and publish it to the S3 bucket - MAIN T
 		-bucket $(S3_BUCKET) \
 		-distribution-id $(DISTRIBUTION_ID) \
 		-source ./public/ \
+		-max-delete 100000 \
 		-v
 	@echo The website is available at \
 		https://$(shell $(DOCKER_RUN) -u $$(id -u):$$(id -g) $(HUGO_DOCKER_IMAGE) ./with-assumed-role "${ROLE_ARN}" \


### PR DESCRIPTION
* adjusted installation procedure of s3deploy to the new name convention used by their developers
* s3deploy version updated to 2.9.0
* increase significantly upper limit of files to delete, otherwise a lot of them stays behind when a major reshuffle happens