### PR TITLE
DOC-4730 - deleted unmenued index pages

### DIFF
--- a/content/en/platform/corda/4.10/_index.md
+++ b/content/en/platform/corda/4.10/_index.md
@@ -1,5 +1,0 @@
-# Corda 4.10 documentation
-
-* [Corda 4.10 Enterprise](4.10/enterprise.html)
-* [Corda 4.10 Community Edition](4.10/community.html)
-

--- a/content/en/platform/corda/4.7/_index.md
+++ b/content/en/platform/corda/4.7/_index.md
@@ -1,3 +1,0 @@
-# Corda 4.7 documentation
-
-* [Corda 4.7 Enterprise](enterprise/_index.md)

--- a/content/en/platform/corda/4.8/_index.md
+++ b/content/en/platform/corda/4.8/_index.md
@@ -1,3 +1,0 @@
-# Corda 4.8 documentation
-
-* [Corda 4.8 Enterprise](4.8/enterprise.html)

--- a/content/en/platform/corda/4.9/_index.md
+++ b/content/en/platform/corda/4.9/_index.md
@@ -1,3 +1,0 @@
-# Corda 4.9 documentation
-
-* [Corda 4.9 Enterprise](4.9/enterprise.html)


### PR DESCRIPTION
"These pages aren't accessible from the menu (as far as I can see) and now in most cases simply link to the Enterprise version. Deleting the would avoid some breaking links down the line too (every time a Community edition is deprecated)."