### PR TITLE
update menu

### DIFF
--- a/content/en/platform/corda/4.10/community/_index.md
+++ b/content/en/platform/corda/4.10/community/_index.md
@@ -9,7 +9,7 @@ menu:
 project: corda
 section_menu: corda-community-4-10
 title: Corda Community Edition 4.10
-version: 'Community Edition 4.10'
+version: 'Community 4.10'
 ---
 
 # Corda Community Edition


### PR DESCRIPTION
Remove "Edition" from Community 4.10 link in version drop-down menu