### PR TITLE
FE-52: Update nav bar so that scrolled text can not be seen

### DIFF
--- a/themes/doks/assets/scss/layouts/_header.scss
+++ b/themes/doks/assets/scss/layouts/_header.scss
@@ -15,7 +15,7 @@ header {
       background: url("images/bg-dark.jpg") no-repeat top center;
       background-size: cover;
       background-attachment: fixed;
-      opacity: 0.8;
+      opacity: 1;
       top: 0;
       left: 0;
       bottom: 0;

--- a/themes/doks/assets/scss/layouts/_home.scss
+++ b/themes/doks/assets/scss/layouts/_home.scss
@@ -73,7 +73,7 @@ body.home {
       background: url("images/bg-dark.jpg") no-repeat top center;
       background-size: cover;
       background-attachment: fixed;
-      opacity: 0.96;
+      opacity: 1;
       top: 0;
       left: 0;
       bottom: 0;


### PR DESCRIPTION
### Overview

Jira: https://r3-cev.atlassian.net/jira/software/c/projects/FE/boards/867?modal=detail&selectedIssue=FE-52 

Changed the opacity of the background image of navbar of the site header to 1. So that scrolled text can not be seen.

See screenshot:
<img width="1792" alt="Screenshot 2023-02-15 at 16 57 19" src="https://user-images.githubusercontent.com/80267895/219104190-11a974d4-aa11-4286-9bfb-c8fda29c1484.png">
