### PR TITLE
8-original-link-fixes

### DIFF
--- a/content/en/platform/corda/1.5/cenm/_index.md
+++ b/content/en/platform/corda/1.5/cenm/_index.md
@@ -110,8 +110,9 @@ For a quick start guide on deploying Corda Enterprise Network Manager services a
 * [CENM User Admin tool](../../../../../en/platform/corda/1.5/cenm/user-admin.md)
 * [CENM Management Console](../../../../../en/platform/corda/1.5/cenm/cenm-console.md)
 * [Config Obfuscation Tool](../../../../../en/platform/corda/4.5/enterprise/tools-config-obfuscator.md)
-* [CRL Endpoint Check Tool](../../../../../en/platform/corda/1.5/cenm/crl-endpoint-check-tool.md)
-* [Embedded shell](../../../../../en/platform/corda/1.5/cenm/shell.md)
+* [CRL Endpoint Check Tool](../cenm/crl-endpoint-check-tool.md)
+* [Embedded shell](../cenm/shell.md)
+* [Embedded shell](../cenm/shells.md)
 
 ## Public Key Infrastructure
 

--- a/content/en/platform/corda/1.5/cenm/_index.md
+++ b/content/en/platform/corda/1.5/cenm/_index.md
@@ -109,9 +109,9 @@ For a quick start guide on deploying Corda Enterprise Network Manager services a
 * [CENM Command-line Interface Tool](../../../../../en/platform/corda/1.5/cenm/cenm-cli-tool.md)
 * [CENM User Admin tool](../../../../../en/platform/corda/1.5/cenm/user-admin.md)
 * [CENM Management Console](../../../../../en/platform/corda/1.5/cenm/cenm-console.md)
-* [Config Obfuscation Tool](../../../../../en/platform/corda/4.5/enterprise/tools-config-obfuscator.md)
-* [CRL Endpoint Check Tool](../cenm/crl-endpoint-check-tool.md)
-* [Embedded shell](../cenm/shell.md)
+* [Config Obfuscation Tool](../../../../../en/platform/corda/4.7/enterprise/tools-config-obfuscator.md)
+* [CRL Endpoint Check Tool](../../../../../en/platform/corda/1.5/cenm/crl-endpoint-check-tool.md)
+* [Embedded shell](../../../../../en/platform/corda/1.5/cenm/shell.md)
 
 ## Public Key Infrastructure
 

--- a/content/en/platform/corda/1.5/cenm/_index.md
+++ b/content/en/platform/corda/1.5/cenm/_index.md
@@ -112,7 +112,6 @@ For a quick start guide on deploying Corda Enterprise Network Manager services a
 * [Config Obfuscation Tool](../../../../../en/platform/corda/4.5/enterprise/tools-config-obfuscator.md)
 * [CRL Endpoint Check Tool](../cenm/crl-endpoint-check-tool.md)
 * [Embedded shell](../cenm/shell.md)
-* [Embedded shell](../cenm/shells.md)
 
 ## Public Key Infrastructure
 

--- a/content/en/platform/corda/4.10/enterprise/flow-state-machines.md
+++ b/content/en/platform/corda/4.10/enterprise/flow-state-machines.md
@@ -660,8 +660,7 @@ loaded off disk again.
 {{< warning >}}
 If a node has flows still in a suspended state, with flow continuations written to disk, it will not be
 possible to upgrade that node to a new version of Corda or your app, because flows must be completely “drained”
-before an upgrade can be performed, and must reach a finished state for draining to complete (see
-[Draining the node](cordapps/upgrading-cordapp.html#draining-the-node) for details). While there are mechanisms for “evolving” serialised data held
+before an upgrade can be performed, and must reach a finished state for draining to complete (see [Draining the node]({{< relref "../enterprise/node-upgrade-notes.md#step-1-drain-the-node" >}}) for details). While there are mechanisms for “evolving” serialised data held
 in the vault, there are no equivalent mechanisms for updating serialised checkpoint data. For this
 reason it is not a good idea to design flows with the intention that they should remain in a suspended
 state for a long period of time, as this will obstruct necessary upgrades to Corda itself. Any

--- a/content/en/platform/corda/4.10/enterprise/operations/deployment/firewall-deployment.md
+++ b/content/en/platform/corda/4.10/enterprise/operations/deployment/firewall-deployment.md
@@ -117,8 +117,7 @@ the `TLS` socket server key and certificates into the `FloatOuter`. The process 
 
 ## Fields
 
-The configuration fields are listed in [Corda Enterprise Firewall configuration fields](corda-firewall-configuration-fields.md).
-
+The configuration fields are listed in [Corda Enterprise Firewall configuration fields](../../../enterprise/node/corda-firewall-configuration-fields.md).
 
 ## Complete example
 
@@ -155,7 +154,7 @@ To facilitate High Availability requirement deployment is split onto two data ce
 {{< note >}}
 This document does not describe how to perform SOCKS5 setup. It is assumed that this type of proxy is correctly configured as part
 of organisation’s IT infrastructure according to best practices/policies for outbound Internet connectivity. Other types of proxies are also supported
-as well as no proxy at all. For more information please see [proxyConfig](corda-firewall-configuration-fields.html#proxyconfig).
+as well as no proxy at all. For more information please see [proxyConfig]({{< relref "../../../enterprise/node/corda-firewall-configuration-fields.md#proxyconfig" >}}).
 {{< /note >}}
 
 

--- a/content/en/platform/corda/4.7/enterprise/flow-state-machines.md
+++ b/content/en/platform/corda/4.7/enterprise/flow-state-machines.md
@@ -661,7 +661,7 @@ loaded off disk again.
 If a node has flows still in a suspended state, with flow continuations written to disk, it will not be
 possible to upgrade that node to a new version of Corda or your app, because flows must be completely “drained”
 before an upgrade can be performed, and must reach a finished state for draining to complete (see
-[Draining the node](cordapps/upgrading-cordapp.html#draining-the-node) for details). While there are mechanisms for “evolving” serialised data held
+[Draining the node]({{< relref "../enterprise/node-upgrade-notes.md#step-1-drain-the-node" >}}) for details). While there are mechanisms for “evolving” serialised data held
 in the vault, there are no equivalent mechanisms for updating serialised checkpoint data. For this
 reason it is not a good idea to design flows with the intention that they should remain in a suspended
 state for a long period of time, as this will obstruct necessary upgrades to Corda itself. Any

--- a/content/en/platform/corda/4.7/enterprise/operations/deployment/firewall-deployment.md
+++ b/content/en/platform/corda/4.7/enterprise/operations/deployment/firewall-deployment.md
@@ -12,6 +12,7 @@ tags:
 title: Firewall deployment
 weight: 30
 ---
+
 # Configuring the Corda Enterprise Firewall
 
 
@@ -117,7 +118,7 @@ the `TLS` socket server key and certificates into the `FloatOuter`. The process 
 
 ## Fields
 
-The configuration fields are listed in [Corda Enterprise Firewall configuration fields](corda-firewall-configuration-fields.md).
+The configuration fields are listed in [Corda Enterprise Firewall configuration fields](../../../enterprise/node/corda-firewall-configuration-fields.md).
 
 
 ## Complete example
@@ -155,10 +156,8 @@ To facilitate High Availability requirement deployment is split onto two data ce
 {{< note >}}
 This document does not describe how to perform SOCKS5 setup. It is assumed that this type of proxy is correctly configured as part
 of organisation’s IT infrastructure according to best practices/policies for outbound Internet connectivity. Other types of proxies are also supported
-as well as no proxy at all. For more information please see [proxyConfig](corda-firewall-configuration-fields.html#proxyconfig).
+as well as no proxy at all. For more information please see [proxyConfig]({{< relref "../../../enterprise/node/corda-firewall-configuration-fields.md#proxyconfig" >}}).
 {{< /note >}}
-
-
 ### Keystores generation
 
 A special tool was created to simplify generation of the keystores. For more information please see HA Utilities.

--- a/content/en/platform/corda/4.8/enterprise/flow-state-machines.md
+++ b/content/en/platform/corda/4.8/enterprise/flow-state-machines.md
@@ -661,7 +661,7 @@ loaded off disk again.
 If a node has flows still in a suspended state, with flow continuations written to disk, it will not be
 possible to upgrade that node to a new version of Corda or your app, because flows must be completely “drained”
 before an upgrade can be performed, and must reach a finished state for draining to complete (see
-[Draining the node](cordapps/upgrading-cordapp.html#draining-the-node) for details). While there are mechanisms for “evolving” serialised data held
+[Draining the node]({{< relref "../enterprise/node-upgrade-notes.md#step-1-drain-the-node" >}}) for details). While there are mechanisms for “evolving” serialised data held
 in the vault, there are no equivalent mechanisms for updating serialised checkpoint data. For this
 reason it is not a good idea to design flows with the intention that they should remain in a suspended
 state for a long period of time, as this will obstruct necessary upgrades to Corda itself. Any

--- a/content/en/platform/corda/4.8/enterprise/operations/deployment/firewall-deployment.md
+++ b/content/en/platform/corda/4.8/enterprise/operations/deployment/firewall-deployment.md
@@ -117,7 +117,7 @@ the `TLS` socket server key and certificates into the `FloatOuter`. The process 
 
 ## Fields
 
-The configuration fields are listed in [Corda Enterprise Firewall configuration fields](corda-firewall-configuration-fields.md).
+The configuration fields are listed in [Corda Enterprise Firewall configuration fields](../../../enterprise/node/corda-firewall-configuration-fields.md).
 
 
 ## Complete example
@@ -155,7 +155,7 @@ To facilitate High Availability requirement deployment is split onto two data ce
 {{< note >}}
 This document does not describe how to perform SOCKS5 setup. It is assumed that this type of proxy is correctly configured as part
 of organisation’s IT infrastructure according to best practices/policies for outbound Internet connectivity. Other types of proxies are also supported
-as well as no proxy at all. For more information please see [proxyConfig](corda-firewall-configuration-fields.html#proxyconfig).
+as well as no proxy at all. For more information please see [proxyConfig]({{< relref "../../../enterprise/node/corda-firewall-configuration-fields.md#proxyconfig" >}}).
 {{< /note >}}
 
 

--- a/content/en/platform/corda/4.9/enterprise/flow-state-machines.md
+++ b/content/en/platform/corda/4.9/enterprise/flow-state-machines.md
@@ -661,7 +661,7 @@ loaded off disk again.
 If a node has flows still in a suspended state, with flow continuations written to disk, it will not be
 possible to upgrade that node to a new version of Corda or your app, because flows must be completely “drained”
 before an upgrade can be performed, and must reach a finished state for draining to complete (see
-[Draining the node](cordapps/upgrading-cordapp.html#draining-the-node) for details). While there are mechanisms for “evolving” serialised data held
+[Draining the node]({{< relref "../enterprise/node-upgrade-notes.md#step-1-drain-the-node" >}}) for details). While there are mechanisms for “evolving” serialised data held
 in the vault, there are no equivalent mechanisms for updating serialised checkpoint data. For this
 reason it is not a good idea to design flows with the intention that they should remain in a suspended
 state for a long period of time, as this will obstruct necessary upgrades to Corda itself. Any

--- a/content/en/platform/corda/4.9/enterprise/operations/deployment/firewall-deployment.md
+++ b/content/en/platform/corda/4.9/enterprise/operations/deployment/firewall-deployment.md
@@ -117,7 +117,7 @@ the `TLS` socket server key and certificates into the `FloatOuter`. The process 
 
 ## Fields
 
-The configuration fields are listed in [Corda Enterprise Firewall configuration fields](corda-firewall-configuration-fields.md).
+The configuration fields are listed in [Corda Enterprise Firewall configuration fields](../../../enterprise/node/corda-firewall-configuration-fields.md  ).
 
 
 ## Complete example
@@ -155,7 +155,7 @@ To facilitate High Availability requirement deployment is split onto two data ce
 {{< note >}}
 This document does not describe how to perform SOCKS5 setup. It is assumed that this type of proxy is correctly configured as part
 of organisation’s IT infrastructure according to best practices/policies for outbound Internet connectivity. Other types of proxies are also supported
-as well as no proxy at all. For more information please see [proxyConfig](corda-firewall-configuration-fields.html#proxyconfig).
+as well as no proxy at all. For more information please see [proxyConfig]({{< relref "../../../enterprise/node/corda-firewall-configuration-fields.md#proxyconfig" >}}).
 {{< /note >}}
 
 


### PR DESCRIPTION
1. 8 fixes applied as per Algolia crawler results for 404s.
2. The links with anchors have moved from absolute links to .md in the recommended relref format. 

Use of the highly recommended (by Hugo) refs and relrefs is not worse than having them in absolute form and may offer benefits longer term. They still don't work with index files, but that is a unique and separate issue. There is also scope to potentially bulk change in one swoop, all absolute links to the new format, but that is for another day. This is just to prove that these are stable in all stages of build (including live) and to see if their use causes 404s to stop for those entries.