### PR TITLE
paulmoloneyr3/DOC-4832/410reqs

### DIFF
--- a/content/en/platform/corda/4.10/enterprise/node/setup/host-prereq.md
+++ b/content/en/platform/corda/4.10/enterprise/node/setup/host-prereq.md
@@ -21,9 +21,9 @@ weight: 2
 
 |Platform|CPU Architecture|Versions|
 |:---------------------------------------|:-----------------------|:--------------|
-|Red Hat Enterprise Linux|x86-64|7.x, 6.x|
+|Red Hat Enterprise Linux|x86-64|8.x, 7.x, 6.x|
 |Suse Linux Enterprise Server|x86-64|12.x, 11.x|
-|Ubuntu Linux|x86-64|16.10, 16.04|
+|Ubuntu Linux|x86-64|16.04, 16.10, 18.04, 20.04|
 |Oracle Linux|x86-64|7.x, 6.x|
 
 {{< /table >}}
@@ -52,7 +52,7 @@ weight: 2
 |Microsoft|x86-64|Azure SQL,SQL Server 2017|Microsoft JDBC Driver 6.4|
 |Oracle|x86-64|11gR2|Oracle JDBC 6|
 |Oracle|x86-64|12cR2|Oracle JDBC 8|
-|PostgreSQL|x86-64|9.6, 10.10, 11.5|PostgreSQL JDBC Driver 42.1.4 / 42.2.9|
+|PostgreSQL|x86-64|9.6, 10.10, 11.5, 13.8|PostgreSQL JDBC Driver 42.1.4 / 42.2.9|
 
 
 {{< /table >}}


### PR DESCRIPTION
The following PRs updated [host-prereq.md](http://host-prereq.md/) for 4.9 and 4.8:

[ENT-8792 - Fixed mentions of Postgres 13.3, should be 13.8 by paulmoloneyr3 · Pull Request #730 · corda/corda-docs-portal](https://github.com/corda/corda-docs-portal/pull/730) 

[DOC-4294: 4.8: Platform support matrix and Host prerequisites and database requirements out of syncDONE](https://r3-cev.atlassian.net/browse/DOC-4294)  

However when 4.10 was merged into main, these changes weren’t included. Will update 4.10.

To summarise:

PostgreSQL changed from 13.3 to 13.8

Red Hat Enterprise Linux - 8.x added

Ubuntu Linux - 18.04 and 20.04 added