### PR TITLE
DOC-4846 - Changed the End of Maintenance date for 4.9 from Mar-2023 …

### DIFF
--- a/content/en/platform/corda/_index.md
+++ b/content/en/platform/corda/_index.md
@@ -64,9 +64,10 @@ Definitions:
 | Corda Enterprise Edition 4.6  | 09/2020         | 09/2022            | 09/2023         | 09/2022        |
 | Corda Enterprise Edition 4.7  | 12/2020         | 12/2022            | 12/2023         | 12/2023        |
 | Corda Enterprise Edition 4.8  | 04/2021         | 10/2023            | 10/2024         | 10/2023        |
-| Corda Enterprise Edition 4.9  | 03/2022         | 03/2023            | 03/2025         | 03/2025        |
-| Corda Enterprise Edition 4.10 | 01/2023         | 01/2024            | 01/2026         | 01/2026        |
-| Corda Community Edition 4.10  | 01/2023         | 01/2024            | 01/2026         | 01/2026        |
+| Corda Enterprise Edition 4.9  | 03/2022         | 03/2024            | 03/2025         | 03/2025        |
+| Corda Community Edition 4.9   | 03/2022         | 03/2024            | 03/2025         | 03/2025        |
+| Corda Enterprise Edition 4.10 | 01/2023         | 01/2025            | 01/2026         | 01/2026        |
+| Corda Community Edition 4.10  | 01/2023         | 01/2025            | 01/2026         | 01/2026        |
 
 {{< /table >}}
 


### PR DESCRIPTION
…to Mar-2024, and for 4.10 (both community and enterprise) from Jan-2024 to Jan-2025; Added back Corda Community Edition 4.9 to the table, with same schedule as Corda Enterprise Edition 4.9