### PR TITLE
DOC-4864 - Configure sitemap to be consumable by Google

### DIFF
--- a/themes/doks/layouts/sitemap.xml
+++ b/themes/doks/layouts/sitemap.xml
@@ -3,7 +3,7 @@
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}{{ if ne .Params.sitemap_exclude true }}
   <url>
-    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <loc>https://docs.r3.com{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
     <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
     <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}


### PR DESCRIPTION
Hugo generates a sitemap, but it only contains relative URLs, which Google can't consume. This task is to update the sitemap template to prefix it with [docs.r3.com](http://docs.r3.com/) so that the sitemap URLs are absolute. Google can then consume this sitemap and (hopefully) it means that new and deleted pages are updated in their index automatically and more quickly.