### PR TITLE
Testing meta data

### DIFF
--- a/content/en/platform/corda/5.0-beta/_index.md
+++ b/content/en/platform/corda/5.0-beta/_index.md
@@ -1,6 +1,6 @@
 ---
 date: '2022-11-23'
-description: "Testing meta data"
+description: "Documentation for the latest beta release for Corda 5.0"
 title: Corda 5.0 Beta 1
 project: corda
 version: 'Corda 5.0 Beta 1'

--- a/content/en/platform/corda/5.0-beta/_index.md
+++ b/content/en/platform/corda/5.0-beta/_index.md
@@ -1,5 +1,6 @@
 ---
 date: '2022-11-23'
+description: "Testing meta data"
 title: Corda 5.0 Beta 1
 project: corda
 version: 'Corda 5.0 Beta 1'

--- a/themes/doks/layouts/partials/head/head.html
+++ b/themes/doks/layouts/partials/head/head.html
@@ -2,6 +2,7 @@
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="description" content="{{ .Description }}">
   {{ block "head/resource-hints" . }}{{ partial "head/resource-hints.html" . }}{{ end }}
   {{ block "head/seo" . }}{{ partial "head/seo.html" . }}{{ end }}
   {{ if .Site.Params.options.algolia -}}


### PR DESCRIPTION
Currently the meta descriptions for all pages in Hugo comes from the setting title = "R3 Documentation" in the config.toml. This is probably why Google then tried to invent its own meta descriptions for our pages, so for example for Corda 5 Beta 1 it’s as shown below.

This ticket is to update the head.html to add a meta description tag which allows you to specify a “description” tag in a page’s front matter. So for example:

`description: "Testing meta data"
title: Corda 5.0 Beta 1`

Will render as:

`<title>Corda 5.0 Beta 1 - R3 Documentation</title><meta name=description content="Testing meta data">`


![image](https://user-images.githubusercontent.com/112477620/222500038-f05e621d-7919-45ef-94b2-fc466b67f014.png)
