### PR TITLE
FE-67: Lefthand menu collapse/expand icon not working for Corda community 4.10

### DIFF
--- a/content/en/platform/corda/4.10/community/legal-info.md
+++ b/content/en/platform/corda/4.10/community/legal-info.md
@@ -8,7 +8,7 @@ date: '2023-01-09'
 menu:
   corda-community-4-10:
     identifier: corda-community-4-10-legal-info
-    parent: 4-10-release-notes
+    parent: corda-community-4-10-release-notes
     weight: 450
     name: Third-party software licence information - 4.10
 tags:

--- a/content/en/platform/corda/4.10/community/release-checksum-os.md
+++ b/content/en/platform/corda/4.10/community/release-checksum-os.md
@@ -4,7 +4,7 @@ date: '2021-07-02'
 menu:
   corda-community-4-10:
     identifier: corda-community-4-10-release-checksum-os
-    parent: 4-10-release-notes
+    parent: corda-community-4-10-release-notes
     weight: 440
     name: "Release files and checksums"
 ---

--- a/content/en/platform/corda/4.10/community/release-notes.md
+++ b/content/en/platform/corda/4.10/community/release-notes.md
@@ -7,7 +7,7 @@ aliases:
 date: '2023-02-01'
 menu:
   corda-community-4-10:
-    identifier: 4-10-release-notes
+    identifier: corda-community-4-10-release-notes
     parent: about-corda-landing-4-10-community
     weight: 10
     name: "Release notes"

--- a/content/en/platform/corda/4.10/community/release-platform-support-matrix.md
+++ b/content/en/platform/corda/4.10/community/release-platform-support-matrix.md
@@ -4,7 +4,7 @@ date: '2021-07-02'
 menu:
   corda-community-4-10:
     identifier: community-platform-support-matrix
-    parent: 4-10-release-notes
+    parent: corda-community-4-10-release-notes
     weight: 450
 ---
 


### PR DESCRIPTION
### Overview
**Jira**: https://r3-cev.atlassian.net/browse/FE-67

The collapse/expand icon (point right when collapsed, and point down when expand) on the lefthand menu does not work for Corda Community 4.10 page. Works fine on all others.

### The cause
the identifier value for `release-notes` set to `"4-10-release-notes"`, then it was used to dynamically setup `data-bs-target` & `aria-controls` attributes for the collapse/expand button. But CSS/html rules string start with number does not works with querySelector, hence the error here. Then it causes the collapse/expand icons not working for the whole page.

<img width="532" alt="image" src="https://user-images.githubusercontent.com/80267895/223706304-012106ee-244b-4eee-abc2-66305c800953.png">

### Fix

Change the identifier and related fields to `"corda-community-4-10-release-notes"` will solve the bug.
<img width="309" alt="image" src="https://user-images.githubusercontent.com/80267895/223708199-295ab619-7776-44ba-83f5-f650a4817907.png">

