### PR TITLE
FE-68: deleted unintentional space added by vs code that causing logo bug.

### DIFF
--- a/themes/doks/layouts/partials/header/header.html
+++ b/themes/doks/layouts/partials/header/header.html
@@ -40,8 +40,8 @@
       {{ end -}}
 
       <a class="navbar-brand order-1" href="{{ .Site.BaseURL | absURL }}" aria-label="{{ .Site.Title }} home page">
-        <img src="{{ " images/r3.svg" | absURL }}" alt="R3 Docs" class="d-lg-none ms-2 me-3" height="32">
-        <img src="{{ " images/r3.svg" | absURL }}" alt="R3 Docs" class="d-none d-lg-inline-block me-4" height="40">
+        <img src="{{ "images/r3.svg" | absURL }}" alt="R3 Docs" class="d-lg-none ms-2 me-3" height="32">
+        <img src="{{ "images/r3.svg" | absURL }}" alt="R3 Docs" class="d-none d-lg-inline-block me-4" height="40">
         <span class="badge bg-secondary docs">Docs</span>
       </a>
 


### PR DESCRIPTION
Quick PR to delete unintentional space added by VS code auto formatting for html file.