### PR TITLE
move-eol-and-archive-list

### DIFF
--- a/content/en/platform/corda/_index.md
+++ b/content/en/platform/corda/_index.md
@@ -22,7 +22,7 @@ menu:
 
 Developers can use the Corda Platform to solve problems by building Corda Distributed Applications, or **CorDapps**. People who want to communicate with each other on Corda can install the same set of CorDapps, which let them define the parameters of their interactions and exchange information and assets. Transactions on Corda are notarized by a specialized type of node, which provides a uniqueness consensus.
 
-## Corda Documentation
+## Currently Supported Corda Documentation
 
 The Corda platform documentation covers the following current versions of the Corda platform which have been officially released:
 
@@ -43,71 +43,6 @@ The Corda platform documentation covers the following current versions of the Co
 
 {{< /table >}}
 
-## End of Life Schedule
-Use the following table to track the end of life schedule for each version of Corda. Each version of Corda Enterprise, Corda Community Edition, and CENM has support available from R3 for a fixed period. After this period has ended, these versions are no longer supported by R3 and associated documentation is archived. You should always aim to upgrade to the latest version of Corda whenever possible.
-
-Definitions:
-
-* **End of maintenance**: This release will no longer receive functional patches after the date shown.
-* **End of security**: This release will no longer be eligible for security patches after the date shown.
-* **End of support**: Support provided by R3 is no longer available after this date.
-
-{{< table >}}
-
-| Corda version                 | Date of release | End of Maintenance | End of security | End of support |
-|-------------------------------|-----------------|--------------------|-----------------|--------------- |
-| Corda Enterprise Edition 4.5  | 06/2020         | 06/2022            | 06/2023         | 06/2022        |
-| Corda Enterprise Edition 4.6  | 09/2020         | 09/2022            | 09/2023         | 09/2022        |
-| Corda Enterprise Edition 4.7  | 12/2020         | 12/2022            | 12/2023         | 12/2023        |
-| Corda Enterprise Edition 4.8  | 04/2021         | 10/2023            | 10/2024         | 10/2023        |
-| Corda Enterprise Edition 4.9  | 03/2022         | 03/2024            | 03/2025         | 03/2025        |
-| Corda Community Edition 4.9   | 03/2022         | 03/2024            | 03/2025         | 03/2025        |
-| Corda Enterprise Edition 4.10 | 01/2023         | 01/2025            | 01/2026         | 01/2026        |
-| Corda Community Edition 4.10  | 01/2023         | 01/2025            | 01/2026         | 01/2026        |
-
-{{< /table >}}
-
 {{< note >}}
-All dates refer to the end of the month indicated.
+Refer to the [End of Life Schedule]({{< relref "./eol-schedule.md" >}}) to know when particular versions will be archived. A list of archived documentation for non-supported versions of Corda Open Source, Corda Enterprise, and CENM, is accessible in [Archived Versions]({{< relref "./archived-versions.md" >}}). 
 {{< /note >}}
-
-## Index of Archived Documentation
-
-Documentation for non-supported releases of Corda Open Source, Corda Enterprise, and CENM, is accessible from the [archived docs](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs) directory of the [corda/corda-docs-portal](https://github.com/corda/corda-docs-portal) repository. The following is a list of direct links for various archived versions:
-
-{{< table >}}
-
-| Product          | Link to archived docs                                              | 
-| :--------------------- | :-------------- | 
-| **Corda 5**   | [Corda 5 Dev Preview 1](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-5/5.0-dev-preview-1) | 
-| **Corda Enterprise**   | [Corda Enterprise 3.0](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/3.0) | 
-|    | [Corda Enterprise 3.1](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/3.1) | 
-|    | [Corda Enterprise 3.2](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/3.2) | 
-|    | [Corda Enterprise 3.3](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/3.3) | 
-|    | [Corda Enterprise 4.0](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/4.0) | 
-|    | [Corda Enterprise 4.1](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/4.1) | 
-|    | [Corda Enterprise 4.2](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/4.2) | 
-|    | [Corda Enterprise 4.3](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/4.3) | 
-|    | [Corda Enterprise 4.4](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/4.4) |
-|    | [Corda Enterprise 4.5](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/4.5) |
-|    | [Corda Enterprise 4.6](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/4.6) | 
-| **CENM**  | [CENM 1.0](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/CENM/1.0) | 
-|   | [CENM 1.1](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/CENM/1.1) | 
-| **Corda Open Source**  | [Corda Open Source 1.0](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/1.0) | 
-|   | [Corda Open Source 2.0](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/2.0) | 
-|   | [Corda Open Source 3.0](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/3.0) | 
-|   | [Corda Open Source 3.1](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/3.1) | 
-|   | [Corda Open Source 3.2](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/3.2) | 
-|   | [Corda Open Source 3.3](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/3.3) | 
-|   | [Corda Open Source 3.4](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/3.4) | 
-|   | [Corda Open Source 4.0](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.0) | 
-|   | [Corda Open Source 4.1](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.1) |  
-|   | [Corda Open Source 4.3](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.3) | 
-|   | [Corda Open Source 4.4](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.4) | 
-|   | [Corda Open Source 4.5](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.5) | 
-|   | [Corda Open Source 4.6](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.6) | 
-|   | [Corda Open Source 4.7](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7) | 
-|   | [Corda Open Source 4.8](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.8) | 
-|   | [Corda Open Source 4.9](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.9) | 
-
-{{< /table >}}

--- a/content/en/platform/corda/archived-versions.md
+++ b/content/en/platform/corda/archived-versions.md
@@ -1,0 +1,49 @@
+---
+date: 
+menu:
+tags:
+- archive
+- archived
+- docs
+title: Index of Archived Documentation
+weight: 
+---
+
+Documentation for non-supported releases of Corda Open Source, Corda Enterprise, and CENM, is accessible from the [archived docs](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs) directory of the [corda/corda-docs-portal](https://github.com/corda/corda-docs-portal) repository. The following is a list of direct links for various archived versions:
+
+{{< table >}}
+
+| Product          | Link to archived docs                                              | 
+| :--------------------- | :-------------- | 
+| **Corda 5**   | [Corda 5 Dev Preview 1](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-5/5.0-dev-preview-1) | 
+| **Corda Enterprise**   | [Corda Enterprise 3.0](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/3.0) | 
+|    | [Corda Enterprise 3.1](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/3.1) | 
+|    | [Corda Enterprise 3.2](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/3.2) | 
+|    | [Corda Enterprise 3.3](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/3.3) | 
+|    | [Corda Enterprise 4.0](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/4.0) | 
+|    | [Corda Enterprise 4.1](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/4.1) | 
+|    | [Corda Enterprise 4.2](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/4.2) | 
+|    | [Corda Enterprise 4.3](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/4.3) | 
+|    | [Corda Enterprise 4.4](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/4.4) |
+|    | [Corda Enterprise 4.5](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/4.5) |
+|    | [Corda Enterprise 4.6](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-enterprise/4.6) | 
+| **CENM**  | [CENM 1.0](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/CENM/1.0) | 
+|   | [CENM 1.1](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/CENM/1.1) | 
+| **Corda Open Source**  | [Corda Open Source 1.0](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/1.0) | 
+|   | [Corda Open Source 2.0](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/2.0) | 
+|   | [Corda Open Source 3.0](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/3.0) | 
+|   | [Corda Open Source 3.1](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/3.1) | 
+|   | [Corda Open Source 3.2](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/3.2) | 
+|   | [Corda Open Source 3.3](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/3.3) | 
+|   | [Corda Open Source 3.4](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/3.4) | 
+|   | [Corda Open Source 4.0](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.0) | 
+|   | [Corda Open Source 4.1](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.1) |  
+|   | [Corda Open Source 4.3](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.3) | 
+|   | [Corda Open Source 4.4](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.4) | 
+|   | [Corda Open Source 4.5](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.5) | 
+|   | [Corda Open Source 4.6](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.6) | 
+|   | [Corda Open Source 4.7](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7) | 
+|   | [Corda Open Source 4.8](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.8) | 
+|   | [Corda Open Source 4.9](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.9) | 
+
+{{< /table >}}

--- a/content/en/platform/corda/eol-schedule.md
+++ b/content/en/platform/corda/eol-schedule.md
@@ -1,0 +1,37 @@
+---
+date: 
+menu:
+tags:
+- end of life
+- schedule
+- support
+title: Documentation End of Life Schedule
+weight: 
+---
+
+Use the following table to track the end of life schedule for each version of Corda. Each version of Corda Enterprise, Corda Community Edition, and CENM has support available from R3 for a fixed period. After this period has ended, these versions are no longer supported by R3 and associated documentation is archived. You should always aim to upgrade to the latest version of Corda whenever possible.
+
+Definitions:
+
+* **End of maintenance**: This release will no longer receive functional patches after the date shown.
+* **End of security**: This release will no longer be eligible for security patches after the date shown.
+* **End of support**: Support provided by R3 is no longer available after this date.
+
+{{< table >}}
+
+| Corda version                 | Date of release | End of Maintenance | End of security | End of support |
+|-------------------------------|-----------------|--------------------|-----------------|--------------- |
+| Corda Enterprise Edition 4.5  | 06/2020         | 06/2022            | 06/2023         | 06/2022        |
+| Corda Enterprise Edition 4.6  | 09/2020         | 09/2022            | 09/2023         | 09/2022        |
+| Corda Enterprise Edition 4.7  | 12/2020         | 12/2022            | 12/2023         | 12/2023        |
+| Corda Enterprise Edition 4.8  | 04/2021         | 10/2023            | 10/2024         | 10/2023        |
+| Corda Enterprise Edition 4.9  | 03/2022         | 03/2024            | 03/2025         | 03/2025        |
+| Corda Community Edition 4.9   | 03/2022         | 03/2024            | 03/2025         | 03/2025        |
+| Corda Enterprise Edition 4.10 | 01/2023         | 01/2025            | 01/2026         | 01/2026        |
+| Corda Community Edition 4.10  | 01/2023         | 01/2025            | 01/2026         | 01/2026        |
+
+{{< /table >}}
+
+{{< note >}}
+All dates refer to the end of the month indicated.
+{{< /note >}}


### PR DESCRIPTION
1. Move EOL content out to dedicated no-index page, as per Elfreda request.
2. Move archived list out to separate no-index page.
3. Just have Corda _index page for current supported docs list and add links to two above sections  moved to their own pages.