### PR TITLE
css-changes-to-tables

### DIFF
--- a/themes/doks/assets/scss/components/_tables.scss
+++ b/themes/doks/assets/scss/components/_tables.scss
@@ -12,15 +12,24 @@ table,
 
   thead {
     tr {
+      background-color: $gray-300;
       border-bottom: 2px solid $gray-200;
+      border-top: 2px solid $gray-200;
+      border-right: 1px solid $gray-200;
+      border-left: 1px solid $gray-200;
+      
     }
   }
 
   tbody {
-    tr {
-      &:nth-child(2n+1) {
-        background-color: $gray-300;
-      }
+    tr { 
+    background-color: $white;
+    border-right: 1px solid $gray-200;
+    border-left: 1px solid $gray-200;
     }
   }
+}
+
+table, th, td {
+  border: 1px solid $gray-200;
 }


### PR DESCRIPTION
1. Header row more distinct (not white, as it is now), plus border top and bottom added to help define.
2. Cancel the alternate rows being grey and white, which is nasty looking.
3. Finally added fine grey borders.

Preview to follow shortly