### PR TITLE
FE-73: Fix breadcrumb's position 

### DIFF
--- a/themes/doks/assets/scss/common/_global.scss
+++ b/themes/doks/assets/scss/common/_global.scss
@@ -418,3 +418,18 @@ figure {
   flex-direction: column;
   align-items: center;
 }
+
+main > nav[aria-label="breadcrumb"] {
+  position: relative;
+
+  @include media-breakpoint-up(md) {
+    position: sticky;
+    padding: 0.5rem;
+    top: 150.5px;
+    background-color: var(--bs-body-bg);
+    width: 100%;
+    padding: 2px;
+    z-index: 1000;
+   }
+}
+

--- a/themes/doks/assets/scss/common/_global.scss
+++ b/themes/doks/assets/scss/common/_global.scss
@@ -428,7 +428,8 @@ main > nav[aria-label="breadcrumb"] {
     background-color: var(--bs-body-bg);
     width: 100%;
     padding: 2px;
-    z-index: 1000;
+    z-index: 900;
+    border-bottom: solid 1px $gray-200;
    }
 }
 

--- a/themes/doks/assets/scss/common/_global.scss
+++ b/themes/doks/assets/scss/common/_global.scss
@@ -424,7 +424,6 @@ main > nav[aria-label="breadcrumb"] {
 
   @include media-breakpoint-up(md) {
     position: sticky;
-    padding: 0.5rem;
     top: 150.5px;
     background-color: var(--bs-body-bg);
     width: 100%;


### PR DESCRIPTION
### Overview

JIRA: https://r3-cev.atlassian.net/browse/FE-73

Breadcrumb is now fixed at the top of pages so that it’s always visible, regardless of user scrolling.

<img width="1081" alt="Screenshot 2023-04-05 at 11 51 29" src="https://user-images.githubusercontent.com/80267895/230090857-afca04b9-5d70-4362-8e98-66aac67b316e.png">

However, the original position/layout is kept for smaller screen (e.g. on mobile deviceS), meaning it will get hidden once user scroll further down the page. Since we got very limited display on small device, it's best practice and common to not to fix non-essential ui element on the screen.
<img width="464" alt="Screenshot 2023-04-05 at 14 16 18" src="https://user-images.githubusercontent.com/80267895/230092243-74ba1a8f-cf8b-4140-9cb0-0c0591702927.png">
