### PR TITLE
FE-73: Fixed the bug caused by fixing breadcrumb position

### DIFF
--- a/themes/doks/assets/js/app.js
+++ b/themes/doks/assets/js/app.js
@@ -5,10 +5,14 @@ window.addEventListener('DOMContentLoaded', () => {
 	const observer = new IntersectionObserver(entries => {
 		entries.forEach(entry => {
 			const id = entry.target.getAttribute('id');
-			if (entry.intersectionRatio > 0) {
-				document.querySelector(`#TableOfContents li a[href="#${id}"]`).classList.add('active');
-			} else {
-				document.querySelector(`#TableOfContents li a[href="#${id}"]`).classList.remove('active');
+      if (entry.intersectionRatio > 0) {
+        if (document.querySelector(`#TableOfContents li a[href="#${id}"]`)) {
+          document.querySelector(`#TableOfContents li a[href="#${id}"]`).classList.add('active');
+        }
+      } else {
+        if (document.querySelector(`#TableOfContents li a[href="#${id}"]`)) {
+          document.querySelector(`#TableOfContents li a[href="#${id}"]`).classList.remove('active');
+        }	
 			}
 		});
   }, { root: null, rootMargin: "-230px",});

--- a/themes/doks/assets/js/app.js
+++ b/themes/doks/assets/js/app.js
@@ -11,7 +11,7 @@ window.addEventListener('DOMContentLoaded', () => {
 				document.querySelector(`#TableOfContents li a[href="#${id}"]`).classList.remove('active');
 			}
 		});
-	});
+  }, { root: null, rootMargin: "-230px",});
 
 	// Track all sections that have an `id` applied
 	document.querySelectorAll('main h2, main h3, main h4, main h5').forEach((section) => {

--- a/themes/doks/assets/scss/common/_global.scss
+++ b/themes/doks/assets/scss/common/_global.scss
@@ -418,3 +418,18 @@ figure {
   flex-direction: column;
   align-items: center;
 }
+
+main > nav[aria-label="breadcrumb"] {
+  position: relative;
+
+  @include media-breakpoint-up(md) {
+    position: sticky;
+    padding: 0.5rem;
+    top: 150.5px;
+    background-color: var(--bs-body-bg);
+    width: 100%;
+    padding: 2px;
+    z-index: 1000;
+   }
+}
+

--- a/themes/doks/assets/scss/common/_global.scss
+++ b/themes/doks/assets/scss/common/_global.scss
@@ -60,7 +60,7 @@ h6,
   .h4,
   .h5,
   .h6 {
-    scroll-margin-top: 155px;
+    scroll-margin-top: 240px;
     margin-bottom: 1.125rem;
   }
 }

--- a/themes/doks/assets/scss/common/_global.scss
+++ b/themes/doks/assets/scss/common/_global.scss
@@ -428,7 +428,8 @@ main > nav[aria-label="breadcrumb"] {
     background-color: var(--bs-body-bg);
     width: 100%;
     padding: 2px;
-    z-index: 1000;
+    z-index: 900;
+    border-bottom: solid 1px $gray-200;
    }
 }
 

--- a/themes/doks/assets/scss/common/_global.scss
+++ b/themes/doks/assets/scss/common/_global.scss
@@ -424,7 +424,6 @@ main > nav[aria-label="breadcrumb"] {
 
   @include media-breakpoint-up(md) {
     position: sticky;
-    padding: 0.5rem;
     top: 150.5px;
     background-color: var(--bs-body-bg);
     width: 100%;


### PR DESCRIPTION
Bug spotted by @nadinequinr3 

It's caused by previous PR on fixing the position of breadcrumb on the page:
If you follow a link to a specific heading for example from right-hand table of content, the heading is hidden by the breadcrumb. 

<img width="1401" alt="Screenshot 2023-04-06 at 10 39 37" src="https://user-images.githubusercontent.com/80267895/230338280-2653e353-a187-4b24-8167-f0aabc0285a1.png">


