### PR TITLE
Update figure shortcode to check for page resource

### DIFF
--- a/themes/doks/layouts/shortcodes/figure.html
+++ b/themes/doks/layouts/shortcodes/figure.html
@@ -25,7 +25,26 @@
 {{ $image := .Page.Resources.GetMatch (printf "*%s*" (.Get "src")) -}}
 <figure>
   {{if $zoom}}<a href="{{$zoom}}" target="_blank">{{end}}
-  <img {{if $image }} src="{{ $image.RelPermalink }}"{{ else }}src="{{$src}}" {{ end }} alt="{{$alt}}"{{if $title }} title="{{$title}}"{{end}}{{if $width}} width="{{$width}}"{{end}}{{if $height }} height="{{$height}}"{{end}}{{if $align}} align="{{$align}}"{{end}}/>
+  <img
+            {{if $image }}
+                src="{{ $image.RelPermalink }}"
+            {{ else }}
+                src="{{$src}}" 
+            {{ end }}
+            alt="{{$alt}}"
+            {{if $title }} 
+                title="{{$title}}"
+            {{end}}
+            {{if $width}}
+                width="{{$width}}"
+            {{end}}
+            {{if $height }}
+                height="{{$height}}"
+            {{end}}
+            {{if $align}}
+                align="{{$align}}"
+            {{end}}
+        />
   {{if $figcaption }}<figcaption>{{$figcaption}}</figcaption>{{end}}
   {{if $zoom}}</a>{{end}}
 </figure>

--- a/themes/doks/layouts/shortcodes/figure.html
+++ b/themes/doks/layouts/shortcodes/figure.html
@@ -22,9 +22,10 @@
   {{ $src = .Get 0 }}
   {{ $alt = .Get 1 }}
 {{end}}
+{{ $image := .Page.Resources.GetMatch (printf "*%s*" (.Get "src")) -}}
 <figure>
   {{if $zoom}}<a href="{{$zoom}}" target="_blank">{{end}}
-  <img src="{{$src}}" alt="{{$alt}}"{{if $title  }} title="{{$title}}"{{end}}{{if $width}} width="{{$width}}"{{end}}{{if $height }} height="{{$height}}"{{end}}{{if $align}} align="{{$align}}"{{end}}/>
+  <img {{if $image }} src="{{ $image.RelPermalink }}"{{ else }}src="{{$src}}" {{ end }} alt="{{$alt}}"{{if $title }} title="{{$title}}"{{end}}{{if $width}} width="{{$width}}"{{end}}{{if $height }} height="{{$height}}"{{end}}{{if $align}} align="{{$align}}"{{end}}/>
   {{if $figcaption }}<figcaption>{{$figcaption}}</figcaption>{{end}}
   {{if $zoom}}</a>{{end}}
 </figure>


### PR DESCRIPTION
The "new" structure of the C5 content uses [Hugo page bundles](https://gohugo.io/content-management/page-bundles/). Currently, the `figure` shortcode used to display images does not process images saved as part of a page bundle.