### PR TITLE
FE-71: Add link heading with icon on hover at the end.

### DIFF
--- a/themes/doks/assets/scss/common/_global.scss
+++ b/themes/doks/assets/scss/common/_global.scss
@@ -461,3 +461,14 @@ summary::after {
 details[open] summary:after {
   content: url("/icons/icon-arrow-up.svg");
 }
+
+.link-heading .link-heading-icon{
+  visibility: hidden;
+}
+
+.link-heading:hover .link-heading-icon{
+  visibility: visible;
+  text-decoration: none;
+  font-size: large;
+  opacity: 0.6;
+}

--- a/themes/doks/layouts/_default/_markup/render-heading.html
+++ b/themes/doks/layouts/_default/_markup/render-heading.html
@@ -1,1 +1,4 @@
-<h{{ .Level }} id="{{ .Anchor | safeURL }}" class="link-heading">{{ .Text | safeHTML }} <a class="link-heading-icon" href="#{{ .Anchor | safeURL }}">🔗</a></h{{ .Level }}>
+<h{{ .Level }} id="{{ .Anchor | safeURL }}" class="link-heading">
+  {{ .Text | safeHTML }} 
+  <a class="link-heading-icon" href="#{{ .Anchor | safeURL }}">🔗</a>
+</h{{ .Level }}>

--- a/themes/doks/layouts/_default/_markup/render-heading.html
+++ b/themes/doks/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,1 @@
+<h{{ .Level }} id="{{ .Anchor | safeURL }}" class="link-heading">{{ .Text | safeHTML }} <a class="link-heading-icon" href="#{{ .Anchor | safeURL }}">🔗</a></h{{ .Level }}>


### PR DESCRIPTION
### Overview

"It would be more intuitive to also have the little ‘link' icon can display beside each heading to make that more intuitive. Probably light grey (so as not in the reader’s face) to the right of each heading. This means that when the reader clicks the link beside a header, the URL at the top changes from [www.xyz.com](http://www.xyz.com/) to [www.xyz.com#headinglink](http://www.xyz.com/#headinglink). That enables customer support and users to send links directly to relevant content, which is helpful as some of our pages are rather large. Probably only relevant for H2"

JIRA: https://r3-cev.atlassian.net/browse/FE-71

Based on the ticket requirement. All headings from `H2` downward have been changed to link heading, with the 🔗 unicode icon at the end only visible when on hovering.

### Screenshots

`Application Networks` heading when on hover state:


<img width="1442" alt="Screenshot 2023-04-24 at 11 45 12" src="https://user-images.githubusercontent.com/80267895/233974398-d5fd362c-afa6-49c9-928f-aaa579f02fc1.png">

When user click on the link icon. the page position will change to highlight the heading from the top. Also the URL change to 
`/key-concepts.html#application-networks`


<img width="1792" alt="Screenshot 2023-04-24 at 11 47 27" src="https://user-images.githubusercontent.com/80267895/233974848-cde89879-355a-4151-9686-68fd80a5717f.png">



