### PR TITLE
add new pages shortcode

### DIFF
--- a/themes/doks/layouts/shortcodes/childpages.html
+++ b/themes/doks/layouts/shortcodes/childpages.html
@@ -1,7 +1,6 @@
 {{- with .Page.Pages -}}
 <ul>
 {{- range sort . ".Params.menu.corda5.weight" -}}
-{{ $weight := .Params.menu.corda5.weight }}
 <li><a href='{{- .Permalink -}}'>{{ .Title }}</a></li>
 {{- end -}}
 </ul>


### PR DESCRIPTION
add a shortcode that will display cross-references to all child pages, sorted by their weight in the corda5 menu 