### PR TITLE
FE-85: Breacrumb background bug when on dark mode.

### DIFF
--- a/themes/doks/assets/scss/common/_dark.scss
+++ b/themes/doks/assets/scss/common/_dark.scss
@@ -579,4 +579,18 @@ body.dark {
     background-color: $body-overlay-dark;
     border: solid 2px $gray-500;
   }
+
+  main > nav[aria-label="breadcrumb"] {
+    position: relative;
+  
+    @include media-breakpoint-up(md) {
+      position: sticky;
+      top: 150.5px;
+      background-color: #262626;
+      width: 100%;
+      padding: 2px;
+      z-index: 900;
+      border-bottom: solid 1px $gray-200;
+     }
+  }
 }


### PR DESCRIPTION
### Overview

JIRA: https://r3-cev.atlassian.net/browse/FE-85

When we fixed the position of the breadcrumb, the background color has to be set so that the content below scrolls through can be hidden.  But when the site is in dark mode, the background color needs to change to match the dark theme. See the screenshot for the bug:
![image](https://user-images.githubusercontent.com/80267895/234258837-f2ae101b-a9af-4e96-9e20-011056c6ae9f.png)

### Solution
So I added the styling for the dark theme background.
Screenshot of the breadcrumb after the fix:
<img width="1402" alt="image" src="https://user-images.githubusercontent.com/80267895/234259107-143255f6-e225-4810-bdd0-c7fbbcfe4fbf.png">
