### PR TITLE
FE-86: Fix table row background issue on dark mode.

### DIFF
--- a/themes/doks/assets/scss/common/_dark.scss
+++ b/themes/doks/assets/scss/common/_dark.scss
@@ -510,7 +510,7 @@ body.dark {
     @extend .table-dark;
 
     > :not(caption) > * > * {
-      background-color: unset;
+      background-color: $body-bg-dark;
       border-bottom: 1px solid $gray-600;
     }
 
@@ -586,7 +586,7 @@ body.dark {
     @include media-breakpoint-up(md) {
       position: sticky;
       top: 150.5px;
-      background-color: #262626;
+      background-color: $body-bg-dark;
       width: 100%;
       padding: 2px;
       z-index: 900;


### PR DESCRIPTION
JIRA: https://r3-cev.atlassian.net/browse/FE-86

Table background not suitable when on dark mode, see screenshot below:
![image](https://user-images.githubusercontent.com/80267895/234327673-f488edcc-5bd5-4f15-b66b-4a6b3da97a83.png)

Changed the table background-color styling to match the main content background. See screenshot after the fix:
<img width="1355" alt="image" src="https://user-images.githubusercontent.com/80267895/234328269-1bf6f884-bde1-4aaf-88ff-d326382cd754.png">
