### PR TITLE
update the variables used in page titles

### DIFF
--- a/themes/doks/layouts/partials/head/seo.html
+++ b/themes/doks/layouts/partials/head/seo.html
@@ -13,7 +13,7 @@
 {{ if .IsHome -}}
   <title>{{ .Site.Params.title }} {{ .Site.Params.titleSeparator }} {{ .Site.Params.titleAddition }}</title>
 {{ else -}}
-  <title>{{ .Title }} {{ .Site.Params.titleSeparator }} {{ .Site.Params.title }}</title>
+  <title>{{ .Title }} {{ .Site.Params.titleSeparator }} {{ if .Params.version }} {{ .Params.version }} {{ .Site.Params.titleSeparator }} {{ else }}{{.Parent.Page.Params.version}}{{ end }}</title>
 {{ end -}}
 
 {{ with .Description -}}


### PR DESCRIPTION
Currently, our page titles are always <H1> - R3 Documentation. It would be more useful to include the product version of the content.
For example, currently, if a user searches Google for a Corda-related term, there is nothing to indicate what version of Corda the results relate to. This will become more important after Corda 5 is released.