### PR TITLE
Rollback Heading Link Changes

### DIFF
--- a/themes/doks/assets/scss/common/_global.scss
+++ b/themes/doks/assets/scss/common/_global.scss
@@ -461,14 +461,3 @@ summary::after {
 details[open] summary:after {
   content: url("/icons/icon-arrow-up.svg");
 }
-
-.link-heading .link-heading-icon{
-  visibility: hidden;
-}
-
-.link-heading:hover .link-heading-icon{
-  visibility: visible;
-  text-decoration: none;
-  font-size: large;
-  opacity: 0.6;
-}

--- a/themes/doks/layouts/_default/_markup/render-heading.html
+++ b/themes/doks/layouts/_default/_markup/render-heading.html
@@ -1,4 +1,0 @@
-<h{{ .Level }} id="{{ .Anchor | safeURL }}" class="link-heading">
-  {{ .Text | safeHTML }} 
-  <a class="link-heading-icon" href="#{{ .Anchor | safeURL }}">🔗</a>
-</h{{ .Level }}>


### PR DESCRIPTION
The implementation in [FE-71: Add link heading with icon on hover at the end. (#1288) · corda/corda-docs-portal@2bee5b2](https://github.com/corda/corda-docs-portal/commit/2bee5b27ed3626670fc894c0a9e23a0c16fc4940) has caused several issues:

- Double H1s on some pages

- icon in search results
- icon in previews of pages