### PR TITLE
FE-71: fixed h1 issue.

### DIFF
--- a/themes/doks/assets/scss/common/_global.scss
+++ b/themes/doks/assets/scss/common/_global.scss
@@ -461,3 +461,10 @@ summary::after {
 details[open] summary:after {
   content: url("/icons/icon-arrow-up.svg");
 }
+
+.link-heading:hover > .link-heading-icon{
+  visibility: visible !important;
+  text-decoration: none;
+  font-size: large;
+  opacity: 0.6;
+}

--- a/themes/doks/layouts/_default/_markup/render-heading.html
+++ b/themes/doks/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,6 @@
+{{ if ne .Level 1 }}
+  <h{{ .Level }} id="{{ .Anchor | safeURL }}" class="link-heading">
+    {{ .Text | safeHTML }} 
+    <a style="visibility: hidden;" class="link-heading-icon" href="#{{ .Anchor | safeURL }}">🔗</a>
+  </h{{ .Level }}>
+{{ end }}


### PR DESCRIPTION
Previous PR: https://github.com/corda/corda-docs-portal/pull/1288
Causing an un-expected h1 issue:  it add an un-necessary link icon to h1 headings, also headings on search panel.
![image](https://user-images.githubusercontent.com/80267895/234605521-16b1402a-c267-4ff1-99e0-29f51e949326.png)

**This is dev PR to be test for search panel.**