### PR TITLE
Niamh25/DOC-5298/Bootstrapping-typo-in-Corda-cluster

### DIFF
--- a/content/en/platform/corda/5.0-beta/corda-cli-reference/rbac-permission-templates.md
+++ b/content/en/platform/corda/5.0-beta/corda-cli-reference/rbac-permission-templates.md
@@ -23,7 +23,7 @@ These roles and permissions enable certain common operations. The creation of us
 | ----------- | ----------- |
 | `UserAdminRole` | Creates roles and permissions and controls all associations between the user roles, and permissions. This role is created at cluster bootstrap by the admin user. This role is created via a REST call enabling to have complete audit trail of the operation performed.       |
 | `VNodeCreatorRole` | Sets all the necessary permissions to create a virtual node, including CPI upload and CPI update. Create this role at cluster bootstrapping time.|
-| `CordaDeveloperRole` | Enables the use of virtual node reset and virtual node status update. This role should be provisioned at cluster boostrap time and should re-use previously created permissions for other roles.|
+| `CordaDeveloperRole` | Enables the use of virtual node reset and virtual node status update. This role should be provisioned at cluster bootstrap time and should re-use previously created permissions for other roles.|
 | `FlowExecutorRole`|  Permits the creation of a role for a given virtual node to start flows and enquire the status of the running flows once the virtual node is created.|
 
 ## Querying Permissions via REST

--- a/content/en/platform/corda/5.0-beta/deploying/deployment-tutorials/deploy-corda-cluster.md
+++ b/content/en/platform/corda/5.0-beta/deploying/deployment-tutorials/deploy-corda-cluster.md
@@ -180,7 +180,7 @@ db:
 Specify the Kafka bootstrap servers as a comma-separated list:
 ```yaml
 kafka:
-  boostrapServers: <KAFKA_BOOTSTRAP_SERVERS>
+  bootstrapServers: <KAFKA_BOOTSTRAP_SERVERS>
 ```
 If desired, a prefix can be applied to all of the Kafka topics used by the Corda deployment. This enables multiple Corda clusters to share a Kafka cluster. For example:
 ```yaml
@@ -477,7 +477,7 @@ db:
           key: "password"
 
 kafka:
-  boostrapServers: "kafka-1.example.com,kafka-2.example.com,kafka-3.example.com"
+  bootstrapServers: "kafka-1.example.com,kafka-2.example.com,kafka-3.example.com"
   tls:
     enabled: true
   sasl:


### PR DESCRIPTION
All typos of "boostrap" changed to "bootstrap"