### PR TITLE
tidy up sample config commands

### DIFF
--- a/content/en/platform/corda/5.0/reference/config-fields/_index.md
+++ b/content/en/platform/corda/5.0/reference/config-fields/_index.md
@@ -15,17 +15,17 @@ This section lists the fields of each Corda configuration section:
 {{< childpages >}}
 Set the fields in a section by sending the configuration fields as JSON to the [config endpoint](../../rest-api/C5_OpenAPI.html#tag/Configuration-API/operation/put_config) of the REST API.
 
-For example, to set fields in the [messaging](messaging.md) section:
+For example, to set fields in the [messaging]({{< relref "./messaging.md" >}}) section using Bash with Curl or PowerShell:
 
    {{< tabs >}}
    {{% tab name="Bash"%}}
    ```shell
-   curl -k -u <username>:<password> -X PUT -d '{"section":"corda.messaging", "version":"1", "config":"{"maxAllowedMessageSize":972800,"publisher":{"closeTimeout":600,"transactional":true},"subscription":{"commitRetries":3,"pollTimeout":500,"processorRetries":3,"processorTimeout":15000,"subscribeRetries":3,"threadStopTimeout":10000}}", "schemaVersion": {"major": 1, "minor": 0}}' "https://localhost:8888/api/v1/config"
+   curl -k -u $REST_API_USER:$REST_API_PASSWORD -X PUT -d '{"section":"corda.messaging", "version":"1", "config":"{"maxAllowedMessageSize":972800,"publisher":{"closeTimeout":600,"transactional":true},"subscription":{"commitRetries":3,"pollTimeout":500,"processorRetries":3,"processorTimeout":15000,"subscribeRetries":3,"threadStopTimeout":10000}}", "schemaVersion": {"major": 1, "minor": 0}}' "$REST_API_URL/api/v1/config"
    ```
    {{% /tab %}}
    {{% tab name="PowerShell" %}}
    ```shell
-   Invoke-RestMethod -SkipCertificateCheck  -Headers @{Authorization=("Basic {0}" -f <username>:<password>)} -Method Put -Uri "https://localhost:8888/api/v1/config" -Body (ConvertTo-Json -Depth 4 @{
+   Invoke-RestMethod -Headers @{Authorization=("Basic {0}" -f $REST_API_USER:$REST_API_PASSWORD)} -Method Put -Uri "$REST_API_URL/api/v1/config" -Body (ConvertTo-Json -Depth 4 @{
     section = "corda.messaging"
     version = 1
     {


### PR DESCRIPTION
The ticket relates to the `corda.sandbox` config but those changes are picked up automatically from GitHub. This PR is just to address some small tweaks to the sample command.