### PR TITLE
 Niamh25/DOC-5173/Corda-deployment-fix

### DIFF
--- a/content/en/platform/corda/5.0/deploying-operating/deployment/deploying/_index.md
+++ b/content/en/platform/corda/5.0/deploying-operating/deployment/deploying/_index.md
@@ -609,7 +609,7 @@ To define `annotation-key-2` for only the crypto worker:
 workers:
   crypto:
     annotations:
-      annotation-key-2/is-safe: "true"
+      annotation-key-2: "some-value"
 ```
 
 ### Example Configuration


### PR DESCRIPTION
 references of annotation-key-2/is-safe changed to annotation-key-2: "some-value"