### PR TITLE
update Beta 4 download locations

### DIFF
--- a/content/en/platform/corda/5.0/application-networks/tooling/installing-corda-cli.md
+++ b/content/en/platform/corda/5.0/application-networks/tooling/installing-corda-cli.md
@@ -20,10 +20,7 @@ Java     | Azul JDK 11
 
 ## Downloading Corda CLI
 
-You can obtain the Corda CLI installer in one of the following ways:
-* Download `platform-jars-Iguana1.0.tar.gz` from the [R3 Customer Hub](https://r3.force.com/)
-and extract `corda-cli-downloader-5.0.0.0-Iguana1.0.zip` from `net\corda\cli\deployment\corda-cli-installer\5.0.0.0-Iguana1.0`.
-* Download `corda-cli-downloader-5.0.0.0-Iguana1.0.zip` directly from the [R3 S3 repository](https://download.corda.net/packages/corda-cli-downloader/5.0.0.0-Iguana1.0/corda-cli-downloader-5.0.0.0-Iguana1.0.zip).
+To obtain the Corda CLI installer, download `platform-jars-Iguana1.0.tar.gz` from the [R3 Developer Portal](https://developer.r3.com/) and extract `corda-cli-downloader-5.0.0.0-Iguana1.0.zip` from `net\corda\cli\deployment\corda-cli-installer\5.0.0.0-Iguana1.0`.
 
 ## Installing on Linux/macOS
 

--- a/content/en/platform/corda/5.0/deploying-operating/deployment/deploying/_index.md
+++ b/content/en/platform/corda/5.0/deploying-operating/deployment/deploying/_index.md
@@ -34,7 +34,7 @@ If your Kubernetes cluster can not pull images from Docker Hub, or if you are de
 
 To push the Corda Community images: 
 
-1. Download `corda-os-worker-images-Iguana1.0.tar` from the [R3 Customer Hub](https://r3.force.com/).
+1. Download `corda-os-worker-images-Iguana1.0.tar` from the [R3 Developer Portal](https://developer.r3.com/).
 
 2. Inflate and load the `corda-os-worker-images-Iguana1.0.tar` file into the local Docker engine with the following command:
    ```shell
@@ -110,13 +110,23 @@ To push the Corda Enterprise images:
 
 ## Download the Corda Helm Chart
 
-If you have access to Docker Hub, you can download the Corda Helm chart using the following command for Corda Community:
+The following sections describe how to download the Corda Helm chart:
+* [Corda Community Helm chart]({{< relref "#corda-community-helm-chart" >}})
+* [Corda Enterprise Helm chart]({{< relref "#corda-enterprise-helm-chart" >}})
+
+### Corda Community Helm chart
+
+If you have access to Docker Hub, you can download the Corda Community Helm chart using the following command:
 
 ```shell
 helm fetch oci://registry-1.docker.io/corda/corda --version 5.0.0-Iguana1.0
 ```
 
-If you do not have access to Docker Hub, or you are deploying Corda Enterprise, you can download the `corda-5.0.0-Iguana1.0.tgz` or `corda-enterprise-5.0.0-Iguana1.0.tgz` file from the [R3 Customer Hub](https://r3.force.com/).
+If you do not have access to Docker Hub, you can download the `corda-5.0.0-Iguana1.0.tgz` file from the [R3 Developer Portal](https://developer.r3.com/).
+
+### Corda Enterprise Helm chart {{< enterprise-icon >}}
+
+You can download the `corda-enterprise-5.0.0-Iguana1.0.tgz` file from the the [R3 Customer Hub](https://r3.force.com/).
 
 ## Configure the Deployment
 

--- a/content/en/platform/corda/5.0/deploying-operating/tooling/installing-corda-cli.md
+++ b/content/en/platform/corda/5.0/deploying-operating/tooling/installing-corda-cli.md
@@ -20,10 +20,7 @@ Java     | Azul JDK 11
 
 ## Downloading Corda CLI
 
-You can obtain the Corda CLI installer in one of the following ways:
-* Download `platform-jars-Iguana1.0.tar.gz` from the [R3 Customer Hub](https://r3.force.com/)
-and extract `corda-cli-downloader-5.0.0.0-Iguana1.0.zip` from `net\corda\cli\deployment\corda-cli-installer\5.0.0.0-Iguana1.0`.
-* Download `corda-cli-downloader-5.0.0.0-Iguana1.0.zip` directly from the [R3 S3 repository](https://download.corda.net/packages/corda-cli-downloader/5.0.0.0-Iguana1.0/corda-cli-downloader-5.0.0.0-Iguana1.0.zip).
+To obtain the Corda CLI installer, download `platform-jars-Iguana1.0.tar.gz` from the [R3 Developer Portal](https://developer.r3.com/) and extract `corda-cli-downloader-5.0.0.0-Iguana1.0.zip` from `net\corda\cli\deployment\corda-cli-installer\5.0.0.0-Iguana1.0`.
 
 ## Installing on Linux/macOS
 

--- a/content/en/platform/corda/5.0/developing-applications/tooling/installing-corda-cli.md
+++ b/content/en/platform/corda/5.0/developing-applications/tooling/installing-corda-cli.md
@@ -21,10 +21,7 @@ Java     | Azul JDK 11
 
 ## Downloading Corda CLI
 
-You can obtain the Corda CLI installer in one of the following ways:
-* Download `platform-jars-Iguana1.0.tar.gz` from the [R3 Customer Hub](https://r3.force.com/)
-and extract `corda-cli-downloader-5.0.0.0-Iguana1.0.zip` from `net\corda\cli\deployment\corda-cli-installer\5.0.0.0-Iguana1.0`.
-* Download `corda-cli-downloader-5.0.0.0-Iguana1.0.zip` directly from the [R3 S3 repository](https://download.corda.net/packages/corda-cli-downloader/5.0.0.0-Iguana1.0/corda-cli-downloader-5.0.0.0-Iguana1.0.zip).
+To obtain the Corda CLI installer, download `platform-jars-Iguana1.0.tar.gz` from the [R3 Developer Portal](https://developer.r3.com/) and extract `corda-cli-downloader-5.0.0.0-Iguana1.0.zip` from `net\corda\cli\deployment\corda-cli-installer\5.0.0.0-Iguana1.0`.
 
 ## Installing on Linux/macOS
 


### PR DESCRIPTION
Customer Hub will now only host Corda Enterprise files.
As per @milan-khan "we should say:
for enterprise customers download from CHUB
for non-enterprise customers download from the Developer Portal"