### PR TITLE
update shortocde for cdl images directory structure

### DIFF
--- a/themes/doks/layouts/shortcodes/figure.html
+++ b/themes/doks/layouts/shortcodes/figure.html
@@ -26,31 +26,27 @@
 <figure>
   {{if $zoom}}<a href="{{$zoom}}" target="_blank">{{end}}
     <img
-      {{if $image }}
+    {{if $image }}
         src="{{ $image.RelPermalink }}"
-      {{ else }}
-        {{ if eq (.Page.Resources.GetMatch $src) true }} 
-          src="{{$src}}" 
-        {{ else }}
-          {{ if eq .Page.Params.version "Corda 5.0"}}	
-             {{ errorf "Image not found: %q" $src "in" $.Page}}
-          {{ end }}
-        {{ end }}
-      {{ end }}
-          alt="{{$alt}}"
-          {{if $title}} 
-            title="{{$title}}"
-          {{end}}
-          {{if $width}}
-            width="{{$width}}"
-          {{end}}
-          {{if $height}}
-            height="{{$height}}"
-          {{end}}
-          {{if $align}}
-            align="{{$align}}"
-          {{end}}
-    />
+    {{ else if or (ne .Page.Params.version "Corda 5.0") (eq (.Page.Resources.GetMatch $src) true) }}
+        src="{{$src}}" 
+    {{ else }}	 
+      {{ errorf "Image not found: %q" $src "in" $.Page}}
+    {{ end }}
+    alt="{{$alt}}"
+    {{if $title }} 
+        title="{{$title}}"
+    {{end}}
+    {{if $width}}
+        width="{{$width}}"
+    {{end}}
+    {{if $height }}
+        height="{{$height}}"
+    {{end}}
+    {{if $align}}
+        align="{{$align}}"
+    {{end}}
+/>
   {{if $figcaption }}<figcaption>{{$figcaption}}</figcaption>{{end}}
   {{if $zoom}}</a>{{end}}
 </figure>


### PR DESCRIPTION
The change to the Figure shortcode to check for image files in a resource bundle did not take into account the structure in the CDL content