### PR TITLE
FE-91: Added tooltip to sidebar link content.

### DIFF
--- a/themes/doks/assets/scss/common/_global.scss
+++ b/themes/doks/assets/scss/common/_global.scss
@@ -437,6 +437,7 @@ main > nav[aria-label="breadcrumb"] {
   position: fixed;
   height: 100%;
   width: 300px;
+  padding-right: 15px;
   overflow: auto;
 }
 

--- a/themes/doks/layouts/partials/sidebar/pages_in_version_menu.html
+++ b/themes/doks/layouts/partials/sidebar/pages_in_version_menu.html
@@ -40,10 +40,10 @@
     {{ else }}
       <li class="nav-item ms-0">
         {{ if hasPrefix .URL "https"}}
-          <a class="docs-link nav-link {{ if $page.IsMenuCurrent $sectionMenuForThisPage . }}active selected{{ end }}" href="{{ .URL }}" target="_blank">
+          <a title="{{ .Name }}" class="docs-link nav-link {{ if $page.IsMenuCurrent $sectionMenuForThisPage . }}active selected{{ end }}" href="{{ .URL }}" target="_blank">
             {{ .Pre }} {{ .Name }}
         {{ else }}
-          <a class="docs-link nav-link {{ if $page.IsMenuCurrent $sectionMenuForThisPage . }}active selected{{ end }}" href="{{ .URL }}">
+          <a title="{{ .Name }}" class="docs-link nav-link {{ if $page.IsMenuCurrent $sectionMenuForThisPage . }}active selected{{ end }}" href="{{ .URL }}">
             {{ .Pre }} {{ .Name }}
         {{ end }}
         </a>


### PR DESCRIPTION
JIRA: https://r3-cev.atlassian.net/browse/FE-91

The simple fix would be to add a tooltip to the truncated context of the sidebar menu.

The option to make the sidebar resizeable can be tricky due to how the base layout of the doc site setup. Also by doing that, we might need to fix any potential bugs introduced by the resizeable sidebar to other UI elements.

Overall tooltip for now is a better fix at the moment.

<img width="567" alt="image" src="https://github.com/corda/corda-docs-portal/assets/80267895/4ac9e3ee-7d3b-4070-95ec-686d23b9bacd">
