### PR TITLE
update "version" value

### DIFF
--- a/content/en/platform/corda/5.0/application-networks/_index.md
+++ b/content/en/platform/corda/5.0/application-networks/_index.md
@@ -2,7 +2,7 @@
 date: '2023-04-20'
 title: "Managing Application Networks"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-networks

--- a/content/en/platform/corda/5.0/application-networks/creating/_index.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/_index.md
@@ -2,7 +2,7 @@
 date: '2023-04-18'
 title: "Creating Application Networks"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-networks-create

--- a/content/en/platform/corda/5.0/application-networks/creating/members/_index.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/members/_index.md
@@ -2,7 +2,7 @@
 date: '2023-04-13'
 title: "Onboarding Members"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-networks-members

--- a/content/en/platform/corda/5.0/application-networks/creating/members/config-node.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/members/config-node.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-13'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Configure Communication Properties"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/creating/members/cpi.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/members/cpi.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-13'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Build and Upload the Member CPI"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/creating/members/key-pairs.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/members/key-pairs.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-13'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Configure Key Pairs and Certificates"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/creating/members/register.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/members/register.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-13'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Register the Member"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/creating/members/virtual-node.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/members/virtual-node.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-13'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Create a Virtual Node"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/creating/mgm/_index.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/mgm/_index.md
@@ -2,7 +2,7 @@
 date: '2023-04-07'
 title: "Onboarding the MGM"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-networks-create

--- a/content/en/platform/corda/5.0/application-networks/creating/mgm/config-node.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/mgm/config-node.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-07'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Configure Communication Properties"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/creating/mgm/cpi.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/mgm/cpi.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-07'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Build the MGM CPI"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/creating/mgm/group-policy.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/mgm/group-policy.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-07'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Export the Group Policy"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/creating/mgm/key-pairs.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/mgm/key-pairs.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-07'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Configure Key Pairs and Certificates"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/creating/mgm/register.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/mgm/register.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-07'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Register the MGM"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/creating/mgm/virtual-node.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/mgm/virtual-node.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-07'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Create a Virtual Node"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/creating/notaries.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/notaries.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-02-23'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Onboarding Notaries"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/creating/optional/_index.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/optional/_index.md
@@ -2,7 +2,7 @@
 date: '2023-04-20'
 title: "Optional Configurations"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-networks-optional

--- a/content/en/platform/corda/5.0/application-networks/creating/optional/mutual-tls-connections.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/optional/mutual-tls-connections.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-02-23'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Mutual TLS Connections"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/creating/optional/session-certificates.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/optional/session-certificates.md
@@ -1,6 +1,6 @@
 ---
 date: '2022-11-15'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Session Certificates"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/managing/member-suspension/_index.md
+++ b/content/en/platform/corda/5.0/application-networks/managing/member-suspension/_index.md
@@ -2,7 +2,7 @@
 date: '2023-05-09'
 title: "Member Suspension"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-networks-member-suspension

--- a/content/en/platform/corda/5.0/application-networks/managing/registration-requests/_index.md
+++ b/content/en/platform/corda/5.0/application-networks/managing/registration-requests/_index.md
@@ -2,7 +2,7 @@
 date: '2023-04-07'
 title: "Member Registration"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-networks-reg-requests

--- a/content/en/platform/corda/5.0/application-networks/managing/registration-requests/configuring-manual-approval-rules.md
+++ b/content/en/platform/corda/5.0/application-networks/managing/registration-requests/configuring-manual-approval-rules.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-07'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Configuring Manual Approval Rules"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/managing/registration-requests/pre-auth/_index.md
+++ b/content/en/platform/corda/5.0/application-networks/managing/registration-requests/pre-auth/_index.md
@@ -2,7 +2,7 @@
 date: '2023-04-20'
 title: "Managing Pre-Authorization"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-networks-pre-auth

--- a/content/en/platform/corda/5.0/application-networks/managing/registration-requests/pre-auth/configuring-pre-auth-rules.md
+++ b/content/en/platform/corda/5.0/application-networks/managing/registration-requests/pre-auth/configuring-pre-auth-rules.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-07'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Configuring Pre-Authentication Rules"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/managing/registration-requests/pre-auth/preauthenticating-tokens.md
+++ b/content/en/platform/corda/5.0/application-networks/managing/registration-requests/pre-auth/preauthenticating-tokens.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-07'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Managing Pre-Authentication Tokens"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/managing/registration-requests/reviewing-registration-requests.md
+++ b/content/en/platform/corda/5.0/application-networks/managing/registration-requests/reviewing-registration-requests.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-03-15'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Reviewing Registration Requests"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/managing/registration-requests/submit-token-reg-request.md
+++ b/content/en/platform/corda/5.0/application-networks/managing/registration-requests/submit-token-reg-request.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-07'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Submitting a Token in a Registration Request"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/plan.md
+++ b/content/en/platform/corda/5.0/application-networks/plan.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-02-23'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Planning Application Networks"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/application-networks/tooling/_index.md
+++ b/content/en/platform/corda/5.0/application-networks/tooling/_index.md
@@ -2,7 +2,7 @@
 date: '2023-02-23'
 title: "Network Operator Tooling"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-networks-tooling

--- a/content/en/platform/corda/5.0/application-networks/tooling/installing-corda-cli.md
+++ b/content/en/platform/corda/5.0/application-networks/tooling/installing-corda-cli.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-12'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-networks-cli

--- a/content/en/platform/corda/5.0/deploying-operating/_index.md
+++ b/content/en/platform/corda/5.0/deploying-operating/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Operating Corda Clusters"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 date: '2023-05-16'
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/config-users/_index.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config-users/_index.md
@@ -2,7 +2,7 @@
 date: '2023-02-23'
 title: "Configuring Users"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-cluster-users

--- a/content/en/platform/corda/5.0/deploying-operating/config-users/administrator.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config-users/administrator.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-24'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Administrator"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/config-users/managing-roles.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config-users/managing-roles.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-24'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Managing Roles and Permissions"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/config-users/permission-system-entities.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config-users/permission-system-entities.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-24'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Permission System Entities"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/config/_index.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Configuring Corda"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 date: '2023-05-16'
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/config/database-connection.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config/database-connection.md
@@ -1,6 +1,6 @@
 ---
 title: "Database Connection Configuration"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 date: '2023-05-16'
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/config/dynamic.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config/dynamic.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-05-16'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Dynamic Configuration"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/config/fields/_index.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config/fields/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Configuration Fields"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 date: '2023-05-16'
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/config/fields/crypto.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config/fields/crypto.md
@@ -1,7 +1,7 @@
 ---
 date: '2023-03-08'
 title: "corda.crypto"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-config-fields

--- a/content/en/platform/corda/5.0/deploying-operating/config/fields/db.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config/fields/db.md
@@ -1,7 +1,7 @@
 ---
 date: '2023-03-08'
 title: "corda.db"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-config-fields

--- a/content/en/platform/corda/5.0/deploying-operating/config/fields/flow.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config/fields/flow.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-03-08'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "corda.flow"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/config/fields/ledger-utxo.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config/fields/ledger-utxo.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-03-08'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "corda.ledger.utxo"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/config/fields/membership.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config/fields/membership.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-03-08'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "corda.membership"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/config/fields/messaging.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config/fields/messaging.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-03-08'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "corda.messaging"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/config/fields/p2p-LinkManager.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config/fields/p2p-LinkManager.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-03-08'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "corda.p2p.linkmanager"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/config/fields/p2p-gateway.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config/fields/p2p-gateway.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-03-08'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "corda.p2p.gateway"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/config/fields/reconciliation.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config/fields/reconciliation.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-03-08'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "corda.reconciliation"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/config/fields/rest.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config/fields/rest.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-03-08'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "corda.rest"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/config/fields/sandbox.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config/fields/sandbox.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-03-08'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "corda.sandbox"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/config/fields/secrets.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config/fields/secrets.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-03-08'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "corda.secrets"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/config/fields/security.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config/fields/security.md
@@ -1,7 +1,7 @@
 ---
 date: '2023-03-08'
 title: "corda.security"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-config-fields

--- a/content/en/platform/corda/5.0/deploying-operating/config/secrets.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config/secrets.md
@@ -1,6 +1,6 @@
 ---
 title: "Configuration Secrets"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 date: '2023-05-16'
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/config/security-policies.md
+++ b/content/en/platform/corda/5.0/deploying-operating/config/security-policies.md
@@ -1,6 +1,6 @@
 ---
 title: "Security Policies"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 date: '2023-05-16'
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/deployment/_index.md
+++ b/content/en/platform/corda/5.0/deploying-operating/deployment/_index.md
@@ -2,7 +2,7 @@
 date: '2023-05-16'
 title: "Corda Deployment"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-cluster-deploy

--- a/content/en/platform/corda/5.0/deploying-operating/deployment/deploying/_index.md
+++ b/content/en/platform/corda/5.0/deploying-operating/deployment/deploying/_index.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-05-11'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Deploying"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/deployment/deploying/manual-bootstrapping.md
+++ b/content/en/platform/corda/5.0/deploying-operating/deployment/deploying/manual-bootstrapping.md
@@ -1,8 +1,8 @@
 ---
 date: '2023-05-11'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Manual Bootstrapping"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-cluster-deploying

--- a/content/en/platform/corda/5.0/deploying-operating/deployment/enterprise.md
+++ b/content/en/platform/corda/5.0/deploying-operating/deployment/enterprise.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-05-11'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Migrating to Corda Enterprise"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/deployment/prerequisites.md
+++ b/content/en/platform/corda/5.0/deploying-operating/deployment/prerequisites.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-05-11'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Prerequisites"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/observability/_index.md
+++ b/content/en/platform/corda/5.0/deploying-operating/observability/_index.md
@@ -2,7 +2,7 @@
 date: '2023-02-23'
 title: "Observability"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-cluster-observability

--- a/content/en/platform/corda/5.0/deploying-operating/observability/k8-probes.md
+++ b/content/en/platform/corda/5.0/deploying-operating/observability/k8-probes.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-05-10'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Kubernetes Liveness and Readiness Probes"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/observability/logs.md
+++ b/content/en/platform/corda/5.0/deploying-operating/observability/logs.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-05-10'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Logs"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/observability/metrics/_index.md
+++ b/content/en/platform/corda/5.0/deploying-operating/observability/metrics/_index.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-05-10'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Metrics"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/observability/metrics/backing-store.md
+++ b/content/en/platform/corda/5.0/deploying-operating/observability/metrics/backing-store.md
@@ -1,8 +1,8 @@
 ---
 date: '2023-06-14'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Backing Store"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-cluster-metrics

--- a/content/en/platform/corda/5.0/deploying-operating/observability/metrics/crypto-worker.md
+++ b/content/en/platform/corda/5.0/deploying-operating/observability/metrics/crypto-worker.md
@@ -1,8 +1,8 @@
 ---
 date: '2023-06-14'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Crypto Worker"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-cluster-metrics

--- a/content/en/platform/corda/5.0/deploying-operating/observability/metrics/db-worker.md
+++ b/content/en/platform/corda/5.0/deploying-operating/observability/metrics/db-worker.md
@@ -1,8 +1,8 @@
 ---
 date: '2023-06-14'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Database Worker"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-cluster-metrics

--- a/content/en/platform/corda/5.0/deploying-operating/observability/metrics/flow-mapper.md
+++ b/content/en/platform/corda/5.0/deploying-operating/observability/metrics/flow-mapper.md
@@ -1,8 +1,8 @@
 ---
 date: '2023-06-14'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Flow Mapper"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-cluster-metrics

--- a/content/en/platform/corda/5.0/deploying-operating/observability/metrics/flow-session.md
+++ b/content/en/platform/corda/5.0/deploying-operating/observability/metrics/flow-session.md
@@ -1,8 +1,8 @@
 ---
 date: '2023-06-14'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Flow Session"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-cluster-metrics

--- a/content/en/platform/corda/5.0/deploying-operating/observability/metrics/flow.md
+++ b/content/en/platform/corda/5.0/deploying-operating/observability/metrics/flow.md
@@ -1,8 +1,8 @@
 ---
 date: '2023-06-14'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Flow"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-cluster-metrics

--- a/content/en/platform/corda/5.0/deploying-operating/observability/metrics/http.md
+++ b/content/en/platform/corda/5.0/deploying-operating/observability/metrics/http.md
@@ -1,8 +1,8 @@
 ---
 date: '2023-06-14'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "HTTP Requests"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-cluster-metrics

--- a/content/en/platform/corda/5.0/deploying-operating/observability/metrics/ledger-uniqueness.md
+++ b/content/en/platform/corda/5.0/deploying-operating/observability/metrics/ledger-uniqueness.md
@@ -1,8 +1,8 @@
 ---
 date: '2023-06-14'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Ledger Uniqueness Checker Client Service"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-cluster-metrics

--- a/content/en/platform/corda/5.0/deploying-operating/observability/metrics/membership-worker.md
+++ b/content/en/platform/corda/5.0/deploying-operating/observability/metrics/membership-worker.md
@@ -1,8 +1,8 @@
 ---
 date: '2023-06-14'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Membership Worker"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-cluster-metrics

--- a/content/en/platform/corda/5.0/deploying-operating/observability/metrics/messaging.md
+++ b/content/en/platform/corda/5.0/deploying-operating/observability/metrics/messaging.md
@@ -1,8 +1,8 @@
 ---
 date: '2023-06-14'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Messaging"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-cluster-metrics

--- a/content/en/platform/corda/5.0/deploying-operating/observability/metrics/p2p.md
+++ b/content/en/platform/corda/5.0/deploying-operating/observability/metrics/p2p.md
@@ -1,8 +1,8 @@
 ---
 date: '2023-06-14'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Peer-to-peer Messages and Sessions"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-cluster-metrics

--- a/content/en/platform/corda/5.0/deploying-operating/observability/metrics/sandbox.md
+++ b/content/en/platform/corda/5.0/deploying-operating/observability/metrics/sandbox.md
@@ -1,8 +1,8 @@
 ---
 date: '2023-06-14'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Sandbox"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-cluster-metrics

--- a/content/en/platform/corda/5.0/deploying-operating/observability/metrics/uniqueness-checker.md
+++ b/content/en/platform/corda/5.0/deploying-operating/observability/metrics/uniqueness-checker.md
@@ -1,8 +1,8 @@
 ---
 date: '2023-06-14'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Uniqueness Checker"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-cluster-metrics

--- a/content/en/platform/corda/5.0/deploying-operating/tooling/_index.md
+++ b/content/en/platform/corda/5.0/deploying-operating/tooling/_index.md
@@ -2,7 +2,7 @@
 date: '2023-05-10'
 title: "Cluster Administrator Tooling"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-cluster-tooling

--- a/content/en/platform/corda/5.0/deploying-operating/tooling/installing-corda-cli.md
+++ b/content/en/platform/corda/5.0/deploying-operating/tooling/installing-corda-cli.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-12'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-cluster-cli

--- a/content/en/platform/corda/5.0/deploying-operating/topology/_index.md
+++ b/content/en/platform/corda/5.0/deploying-operating/topology/_index.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-02-23'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Infrastructure Topology"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/deploying-operating/vnodes/_index.md
+++ b/content/en/platform/corda/5.0/deploying-operating/vnodes/_index.md
@@ -2,7 +2,7 @@
 date: '2023-02-23'
 title: "Managing Virtual Nodes"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-cluster-nodes

--- a/content/en/platform/corda/5.0/deploying-operating/vnodes/retrieving.md
+++ b/content/en/platform/corda/5.0/deploying-operating/vnodes/retrieving.md
@@ -2,7 +2,7 @@
 date: '2023-06-12'
 title: "Retrieving Virtual Nodes"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-cluster-nodes-retrieving

--- a/content/en/platform/corda/5.0/deploying-operating/vnodes/state.md
+++ b/content/en/platform/corda/5.0/deploying-operating/vnodes/state.md
@@ -2,7 +2,7 @@
 date: '2023-06-12'
 title: "Setting the State of Virtual Nodes"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-cluster-nodes-state

--- a/content/en/platform/corda/5.0/deploying-operating/vnodes/upgrade-cpi.md
+++ b/content/en/platform/corda/5.0/deploying-operating/vnodes/upgrade-cpi.md
@@ -2,7 +2,7 @@
 date: '2023-06-12'
 title: "Upgrading a CPI"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-cluster-nodes-upgrade

--- a/content/en/platform/corda/5.0/deploying-operating/vnodes/x500.md
+++ b/content/en/platform/corda/5.0/deploying-operating/vnodes/x500.md
@@ -2,7 +2,7 @@
 date: '2023-06-12'
 title: "Rules for X.500 Member Names"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-cluster-nodes-x500

--- a/content/en/platform/corda/5.0/developing-applications/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Developing Applications"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 date: 2023-04-21
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/api/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/api/_index.md
@@ -2,7 +2,7 @@
 date: '2023-04-24'
 title: "Corda API"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-api

--- a/content/en/platform/corda/5.0/developing-applications/api/amqp-serialization-cordapp-custom-serializers.md
+++ b/content/en/platform/corda/5.0/developing-applications/api/amqp-serialization-cordapp-custom-serializers.md
@@ -1,6 +1,6 @@
 ---
 date: '2022-09-21T14:27:00+01:00'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Pluggable Serializers for CorDapps"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/api/amqp-serialization-default-evolution.md
+++ b/content/en/platform/corda/5.0/developing-applications/api/amqp-serialization-default-evolution.md
@@ -1,6 +1,6 @@
 ---
 date: '2022-09-21T14:27:00+01:00'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Default Class Evolution"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/api/amqp-serialization-enum-evolution.md
+++ b/content/en/platform/corda/5.0/developing-applications/api/amqp-serialization-enum-evolution.md
@@ -1,6 +1,6 @@
 ---
 date: '2022-09-21T14:27:00+01:00'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Enum Evolution"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/api/api-base.md
+++ b/content/en/platform/corda/5.0/developing-applications/api/api-base.md
@@ -1,6 +1,6 @@
 ---
 date: '2021-04-24T00:00:00Z'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "net.corda.v5.base"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/api/api-crypto-extensions.md
+++ b/content/en/platform/corda/5.0/developing-applications/api/api-crypto-extensions.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-02-10'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "net.corda.v5.crypto"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/api/api-ledger-token-selection.md
+++ b/content/en/platform/corda/5.0/developing-applications/api/api-ledger-token-selection.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-01-30'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "net.corda.v5.ledger.utxo.token.selection"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/api/api-membership.md
+++ b/content/en/platform/corda/5.0/developing-applications/api/api-membership.md
@@ -1,6 +1,6 @@
 ---
 date: '2022-09-06'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "net.corda.v5.membership"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/api/api-serialisation.md
+++ b/content/en/platform/corda/5.0/developing-applications/api/api-serialisation.md
@@ -1,6 +1,6 @@
 ---
 date: '2022-09-21T14:27:00+01:00'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "net.corda.v5.serialization"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/api/application/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/api/application/_index.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-02-10'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "net.corda.v5.application"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/api/application/crypto.md
+++ b/content/en/platform/corda/5.0/developing-applications/api/application/crypto.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-02-10'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "net.corda.v5.application.crypto"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/api/application/flows.md
+++ b/content/en/platform/corda/5.0/developing-applications/api/application/flows.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-02-10'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "net.corda.v5.application.flows"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/api/application/marshalling.md
+++ b/content/en/platform/corda/5.0/developing-applications/api/application/marshalling.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-02-10'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "net.corda.v5.application.marshalling"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/api/application/membership.md
+++ b/content/en/platform/corda/5.0/developing-applications/api/application/membership.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-02-10'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "net.corda.v5.application.membership"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/api/application/messaging.md
+++ b/content/en/platform/corda/5.0/developing-applications/api/application/messaging.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-02-10'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "net.corda.v5.application.messaging"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/api/application/persistence.md
+++ b/content/en/platform/corda/5.0/developing-applications/api/application/persistence.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-02-10'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "net.corda.v5.application.persistence"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/api/application/serialization.md
+++ b/content/en/platform/corda/5.0/developing-applications/api/application/serialization.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-02-10'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "net.corda.v5.application.serialization"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/basic-cordapp/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/basic-cordapp/_index.md
@@ -2,7 +2,7 @@
 date: '2023-05-03'
 title: "Building Your First CorDapp"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-develop-first-cordapp

--- a/content/en/platform/corda/5.0/developing-applications/basic-cordapp/contract.md
+++ b/content/en/platform/corda/5.0/developing-applications/basic-cordapp/contract.md
@@ -1,7 +1,7 @@
 ---
 date: '2023-05-03'
 title: "Write Contracts"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-develop-first-cordapp-contract

--- a/content/en/platform/corda/5.0/developing-applications/basic-cordapp/flows.md
+++ b/content/en/platform/corda/5.0/developing-applications/basic-cordapp/flows.md
@@ -1,7 +1,7 @@
 ---
 date: '2023-05-03'
 title: "Write Flows"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-develop-first-cordapp-flows

--- a/content/en/platform/corda/5.0/developing-applications/basic-cordapp/setup.md
+++ b/content/en/platform/corda/5.0/developing-applications/basic-cordapp/setup.md
@@ -1,7 +1,7 @@
 ---
 date: '2023-05-03'
 title: "Initial Setup"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-develop-first-cordapp-setup

--- a/content/en/platform/corda/5.0/developing-applications/basic-cordapp/state.md
+++ b/content/en/platform/corda/5.0/developing-applications/basic-cordapp/state.md
@@ -1,7 +1,7 @@
 ---
 date: '2023-05-03'
 title: "Write States"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-develop-first-cordapp-state

--- a/content/en/platform/corda/5.0/developing-applications/basic-cordapp/testing.md
+++ b/content/en/platform/corda/5.0/developing-applications/basic-cordapp/testing.md
@@ -1,7 +1,7 @@
 ---
 date: '2023-05-03'
 title: "Test Your CorDapp"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-develop-first-cordapp-testing

--- a/content/en/platform/corda/5.0/developing-applications/components/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/components/_index.md
@@ -2,7 +2,7 @@
 date: '2023-02-23'
 title: "CorDapp Components"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-develop-components

--- a/content/en/platform/corda/5.0/developing-applications/components/flows.md
+++ b/content/en/platform/corda/5.0/developing-applications/components/flows.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-02-23'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Flows"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/components/ledger/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/components/ledger/_index.md
@@ -2,7 +2,7 @@
 date: '2023-02-23'
 title: "Ledger"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-develop-ledger

--- a/content/en/platform/corda/5.0/developing-applications/getting-started/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/getting-started/_index.md
@@ -2,7 +2,7 @@
 date: '2023-02-23'
 title: "Getting Started Using the CSDE"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-develop-get-started

--- a/content/en/platform/corda/5.0/developing-applications/getting-started/configure-the-network-participants/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/getting-started/configure-the-network-participants/_index.md
@@ -1,6 +1,6 @@
 ---
 date: '2022-09-20'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Configuring the Network Participants"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/getting-started/cordapp-standard-development-environment/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/getting-started/cordapp-standard-development-environment/_index.md
@@ -1,7 +1,7 @@
 ---
 date: '2022-09-19'
 title: "Installing the CSDE"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-develop-get-started

--- a/content/en/platform/corda/5.0/developing-applications/getting-started/debugging-against-local-corda/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/getting-started/debugging-against-local-corda/_index.md
@@ -1,6 +1,6 @@
 ---
 date: '2022-09-20'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Debugging Against Local Corda"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/getting-started/first-flow/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/getting-started/first-flow/_index.md
@@ -1,6 +1,6 @@
 ---
 date: '2022-09-20'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Your First Flow"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/getting-started/first-flow/code-java.md
+++ b/content/en/platform/corda/5.0/developing-applications/getting-started/first-flow/code-java.md
@@ -1,6 +1,6 @@
 ---
 date: '2022-10-19'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Java Flow Code Walkthrough"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/getting-started/first-flow/code-kotlin.md
+++ b/content/en/platform/corda/5.0/developing-applications/getting-started/first-flow/code-kotlin.md
@@ -1,6 +1,6 @@
 ---
 date: '2022-10-19'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Kotlin Flow Code Walkthrough"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/getting-started/prerequisites/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/getting-started/prerequisites/_index.md
@@ -1,6 +1,6 @@
 ---
 date: '2022-09-19'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Prerequisites for the CSDE"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/getting-started/reset-csde.md
+++ b/content/en/platform/corda/5.0/developing-applications/getting-started/reset-csde.md
@@ -1,6 +1,6 @@
 ---
 date: '2022-09-22'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Resetting the CSDE"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/getting-started/running-your-first-cordapp/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/getting-started/running-your-first-cordapp/_index.md
@@ -1,6 +1,6 @@
 ---
 date: '2022-09-19'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Running Your First CorDapp"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/getting-started/utxo-advanced-ledger-extensions/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/getting-started/utxo-advanced-ledger-extensions/_index.md
@@ -2,7 +2,7 @@
 date: '2023-06-01'
 title: "UTXO Advanced Ledger Extensions Library"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-utxo-advanced-ledger-extensions

--- a/content/en/platform/corda/5.0/developing-applications/getting-started/utxo-advanced-ledger-extensions/building-basic-contract-design.md
+++ b/content/en/platform/corda/5.0/developing-applications/getting-started/utxo-advanced-ledger-extensions/building-basic-contract-design.md
@@ -2,7 +2,7 @@
 date: '2023-06-01'
 title: "Building Basic Contract Design"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-utxo-ledger-building-basic-contract-design

--- a/content/en/platform/corda/5.0/developing-applications/getting-started/utxo-advanced-ledger-extensions/ledger-extensions-api-reference.md
+++ b/content/en/platform/corda/5.0/developing-applications/getting-started/utxo-advanced-ledger-extensions/ledger-extensions-api-reference.md
@@ -2,7 +2,7 @@
 date: '2023-06-01'
 title: "Ledger Extensions API Reference"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-utxo-ledger-extensions-api-reference

--- a/content/en/platform/corda/5.0/developing-applications/getting-started/utxo-ledger-example-cordapp/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/getting-started/utxo-ledger-example-cordapp/_index.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-01-27'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "UTXO Ledger Example CorDapp"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/getting-started/utxo-ledger-example-cordapp/cordapp-chat/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/getting-started/utxo-ledger-example-cordapp/cordapp-chat/_index.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-01-23'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Chat CorDapp Design"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/getting-started/utxo-ledger-example-cordapp/running-the-chat-cordapp/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/getting-started/utxo-ledger-example-cordapp/running-the-chat-cordapp/_index.md
@@ -1,7 +1,7 @@
 ---
 date: '2023-01-23'
 title: "Running the Chat CorDapp"
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-utxo-example

--- a/content/en/platform/corda/5.0/developing-applications/network-types/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/network-types/_index.md
@@ -2,7 +2,7 @@
 date: '2023-02-23'
 title: "Network Types"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-develop-networks

--- a/content/en/platform/corda/5.0/developing-applications/notaries/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/notaries/_index.md
@@ -2,7 +2,7 @@
 date: '2023-02-23'
 title: "Notaries"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-develop-notaries

--- a/content/en/platform/corda/5.0/developing-applications/notaries/notary-plugin-cordapps/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/notaries/notary-plugin-cordapps/_index.md
@@ -2,7 +2,7 @@
 date: '2023-05-16'
 title: "Notary Plugin CorDapps"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: notary-plugin-cordapps

--- a/content/en/platform/corda/5.0/developing-applications/packaging/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/packaging/_index.md
@@ -2,7 +2,7 @@
 date: '2023-02-23'
 title: "Packaging"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-develop-packaging

--- a/content/en/platform/corda/5.0/developing-applications/packaging/code-signing/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/packaging/code-signing/_index.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-05-18'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Code Signing"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/packaging/code-signing/custom-cert.md
+++ b/content/en/platform/corda/5.0/developing-applications/packaging/code-signing/custom-cert.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-05-18'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Signing Packages with a Custom Certificate"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/packaging/code-signing/signing-cli.md
+++ b/content/en/platform/corda/5.0/developing-applications/packaging/code-signing/signing-cli.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-05-18'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 title: "Signing Packages Using Corda CLI"
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/developing-applications/packaging/cpb.md
+++ b/content/en/platform/corda/5.0/developing-applications/packaging/cpb.md
@@ -2,7 +2,7 @@
 date: '2023-02-23'
 title: "Build a CPB"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-develop-packaging

--- a/content/en/platform/corda/5.0/developing-applications/packaging/cpk-plugin.md
+++ b/content/en/platform/corda/5.0/developing-applications/packaging/cpk-plugin.md
@@ -2,7 +2,7 @@
 date: '2023-06-06'
 title: "CPK Gradle Plugin"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-develop-packaging

--- a/content/en/platform/corda/5.0/developing-applications/packaging/cpk.md
+++ b/content/en/platform/corda/5.0/developing-applications/packaging/cpk.md
@@ -2,7 +2,7 @@
 date: '2023-02-23'
 title: "Build a CPK"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-develop-packaging

--- a/content/en/platform/corda/5.0/developing-applications/testing/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/testing/_index.md
@@ -2,7 +2,7 @@
 date: '2023-02-23'
 title: "Testing CorDapps"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-develop-test

--- a/content/en/platform/corda/5.0/developing-applications/tooling/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/tooling/_index.md
@@ -2,7 +2,7 @@
 date: '2023-02-23'
 title: "Application Developer Tooling"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-develop-tooling

--- a/content/en/platform/corda/5.0/developing-applications/tooling/installing-corda-cli.md
+++ b/content/en/platform/corda/5.0/developing-applications/tooling/installing-corda-cli.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-04-12'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-develop-cli

--- a/content/en/platform/corda/5.0/developing-applications/upgrading/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/upgrading/_index.md
@@ -2,7 +2,7 @@
 date: '2023-05-18'
 title: "Upgrading CorDapps"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-upgrading

--- a/content/en/platform/corda/5.0/introduction/_index.md
+++ b/content/en/platform/corda/5.0/introduction/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Introduction"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 date: 2023-04-21
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/introduction/about-the-docs/_index.md
+++ b/content/en/platform/corda/5.0/introduction/about-the-docs/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "About the Docs"
 date: 2023-04-21
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-about-the-docs

--- a/content/en/platform/corda/5.0/introduction/corda-overview.md
+++ b/content/en/platform/corda/5.0/introduction/corda-overview.md
@@ -1,7 +1,7 @@
 ---
 title: "Corda Overview"
 date: 2023-04-21
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-background

--- a/content/en/platform/corda/5.0/introduction/glossary.md
+++ b/content/en/platform/corda/5.0/introduction/glossary.md
@@ -1,7 +1,7 @@
 ---
 title: "Glossary"
 date: 2023-04-21
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-glossary

--- a/content/en/platform/corda/5.0/introduction/personas.md
+++ b/content/en/platform/corda/5.0/introduction/personas.md
@@ -1,7 +1,7 @@
 ---
 title: "Personas"
 date: 2023-05-31
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-personas

--- a/content/en/platform/corda/5.0/introduction/release-notes/5.0.0.md
+++ b/content/en/platform/corda/5.0/introduction/release-notes/5.0.0.md
@@ -1,7 +1,7 @@
 ---
 title: "Corda 5.0 Beta 4 Release Notes"
 date: 2023-05-23
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-release-notes-beta4

--- a/content/en/platform/corda/5.0/introduction/release-notes/_index.md
+++ b/content/en/platform/corda/5.0/introduction/release-notes/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Release Notes"
 date: 2023-05-23
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-release-notes

--- a/content/en/platform/corda/5.0/introduction/release-notes/legal-info/CSDE-cordapp-template-java-modified-snyk-license-report.html
+++ b/content/en/platform/corda/5.0/introduction/release-notes/legal-info/CSDE-cordapp-template-java-modified-snyk-license-report.html
@@ -1,7 +1,7 @@
 ---
 title: "corda-CSDE-cordapp-template-java"
 date: 2023-06-12
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-release-notes-corda-csde-java

--- a/content/en/platform/corda/5.0/introduction/release-notes/legal-info/CSDE-cordapp-template-kotlin-modified-snyk-license-report.html
+++ b/content/en/platform/corda/5.0/introduction/release-notes/legal-info/CSDE-cordapp-template-kotlin-modified-snyk-license-report.html
@@ -1,7 +1,7 @@
 ---
 title: "corda-CSDE-cordapp-template-kotlin"
 date: 2023-06-12
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-release-notes-corda-csde-kotlin

--- a/content/en/platform/corda/5.0/introduction/release-notes/legal-info/_index.md
+++ b/content/en/platform/corda/5.0/introduction/release-notes/legal-info/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Third-Party Software Notices and Information"
 date: 2023-05-23
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     parent: corda5-release-notes

--- a/content/en/platform/corda/5.0/introduction/release-notes/legal-info/corda-api-modified-snyk-license-report.html
+++ b/content/en/platform/corda/5.0/introduction/release-notes/legal-info/corda-api-modified-snyk-license-report.html
@@ -1,7 +1,7 @@
 ---
 title: "corda-api"
 date: 2023-06-12
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-release-notes-corda-api

--- a/content/en/platform/corda/5.0/introduction/release-notes/legal-info/corda-cli-plugin-host-modified-snyk-license-report.html
+++ b/content/en/platform/corda/5.0/introduction/release-notes/legal-info/corda-cli-plugin-host-modified-snyk-license-report.html
@@ -1,7 +1,7 @@
 ---
 title: "corda-cli"
 date: 2023-06-12
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-release-notes-corda-cli

--- a/content/en/platform/corda/5.0/introduction/release-notes/legal-info/corda-gradle-plugins-release_7_0_3-modified-snykLicenseReport.html
+++ b/content/en/platform/corda/5.0/introduction/release-notes/legal-info/corda-gradle-plugins-release_7_0_3-modified-snykLicenseReport.html
@@ -1,7 +1,7 @@
 ---
 title: "corda-gradle-plugin"
 date: 2023-06-12
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-release-notes-corda-gradle

--- a/content/en/platform/corda/5.0/introduction/release-notes/legal-info/corda-runtime-os-modified-snyk-license-report.html
+++ b/content/en/platform/corda/5.0/introduction/release-notes/legal-info/corda-runtime-os-modified-snyk-license-report.html
@@ -1,7 +1,7 @@
 ---
 title: "corda-runtime-os"
 date: 2023-06-12
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-release-notes-corda-runtime-os

--- a/content/en/platform/corda/5.0/introduction/release-notes/legal-info/corda-utxo-ledger-extensions-modified-snyk-license-report.html
+++ b/content/en/platform/corda/5.0/introduction/release-notes/legal-info/corda-utxo-ledger-extensions-modified-snyk-license-report.html
@@ -1,7 +1,7 @@
 ---
 title: "corda-uxto-ledger-extensions"
 date: 2023-06-12
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-release-notes-ledger-extensions

--- a/content/en/platform/corda/5.0/introduction/release-notes/legal-info/corda5-enterprise-modified-snyk-license-report.html
+++ b/content/en/platform/corda/5.0/introduction/release-notes/legal-info/corda5-enterprise-modified-snyk-license-report.html
@@ -1,7 +1,7 @@
 ---
 title: "corda-enterprise"
 date: 2023-06-12
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-release-notes-corda-enterprise

--- a/content/en/platform/corda/5.0/introduction/release-notes/legal-info/csde-gradle-plugin-modified-snyk-license-report.html
+++ b/content/en/platform/corda/5.0/introduction/release-notes/legal-info/csde-gradle-plugin-modified-snyk-license-report.html
@@ -1,7 +1,7 @@
 ---
 title: "corda-csde-gradle-plugin"
 date: 2023-06-12
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-release-notes-csde-gradle-plugin

--- a/content/en/platform/corda/5.0/introduction/release-notes/platform-support.md
+++ b/content/en/platform/corda/5.0/introduction/release-notes/platform-support.md
@@ -1,7 +1,7 @@
 ---
 title: "Corda 5.0 Platform Support"
 date: 2023-05-23
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-platform-support

--- a/content/en/platform/corda/5.0/introduction/use-cases.md
+++ b/content/en/platform/corda/5.0/introduction/use-cases.md
@@ -1,7 +1,7 @@
 ---
 title: "Use Case Examples"
 date: 2023-04-21
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-use-cases

--- a/content/en/platform/corda/5.0/key-concepts/_index.md
+++ b/content/en/platform/corda/5.0/key-concepts/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Key Concepts"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 date: 2023-04-21
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/key-concepts/fundamentals/CorDapps/_index.md
+++ b/content/en/platform/corda/5.0/key-concepts/fundamentals/CorDapps/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "CorDapps"
 date: 2023-06-07
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-fundamentals-cordapps

--- a/content/en/platform/corda/5.0/key-concepts/fundamentals/_index.md
+++ b/content/en/platform/corda/5.0/key-concepts/fundamentals/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Fundamentals"
 date: 2023-04-21
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-fundamentals

--- a/content/en/platform/corda/5.0/key-concepts/fundamentals/application-networks/_index.md
+++ b/content/en/platform/corda/5.0/key-concepts/fundamentals/application-networks/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Application Networks"
 date: 2023-06-07
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-fundamentals-app-networks

--- a/content/en/platform/corda/5.0/key-concepts/fundamentals/chain-of-trust/_index.md
+++ b/content/en/platform/corda/5.0/key-concepts/fundamentals/chain-of-trust/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Chain of Trust"
 date: 2023-06-07
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-fundamentals-chain-trust

--- a/content/en/platform/corda/5.0/key-concepts/fundamentals/dlt/_index.md
+++ b/content/en/platform/corda/5.0/key-concepts/fundamentals/dlt/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Distributed Ledger Technology"
 date: 2023-06-07
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-fundamentals-DLT

--- a/content/en/platform/corda/5.0/key-concepts/fundamentals/ledger/_index.md
+++ b/content/en/platform/corda/5.0/key-concepts/fundamentals/ledger/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "The Corda Ledger"
 date: 2023-06-08
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-fundamentals-ledger

--- a/content/en/platform/corda/5.0/key-concepts/fundamentals/ledger/consensus/_index.md
+++ b/content/en/platform/corda/5.0/key-concepts/fundamentals/ledger/consensus/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Consensus"
 date: 2023-06-08
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-fundamentals-ledger-consensus

--- a/content/en/platform/corda/5.0/key-concepts/fundamentals/ledger/flows/_index.md
+++ b/content/en/platform/corda/5.0/key-concepts/fundamentals/ledger/flows/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Flows"
 date: 2023-06-08
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-fundamentals-ledger-flows

--- a/content/en/platform/corda/5.0/key-concepts/fundamentals/ledger/notaries/_index.md
+++ b/content/en/platform/corda/5.0/key-concepts/fundamentals/ledger/notaries/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Notaries"
 date: 2023-06-08
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-fundamentals-ledger-notaries

--- a/content/en/platform/corda/5.0/key-concepts/fundamentals/ledger/smart-contracts/_index.md
+++ b/content/en/platform/corda/5.0/key-concepts/fundamentals/ledger/smart-contracts/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Smart Contracts"
 date: 2023-06-08
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-fundamentals-ledger-smart-contracts

--- a/content/en/platform/corda/5.0/key-concepts/fundamentals/ledger/states/_index.md
+++ b/content/en/platform/corda/5.0/key-concepts/fundamentals/ledger/states/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "States"
 date: 2023-06-08
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-fundamentals-ledger-states

--- a/content/en/platform/corda/5.0/key-concepts/fundamentals/ledger/time-windows/_index.md
+++ b/content/en/platform/corda/5.0/key-concepts/fundamentals/ledger/time-windows/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Time Windows"
 date: 2023-06-08
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-fundamentals-ledger-time-window

--- a/content/en/platform/corda/5.0/key-concepts/fundamentals/ledger/transactions/_index.md
+++ b/content/en/platform/corda/5.0/key-concepts/fundamentals/ledger/transactions/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Transactions"
 date: 2023-06-08
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-fundamentals-ledger-transactions

--- a/content/en/platform/corda/5.0/key-concepts/fundamentals/ledger/vault/_index.md
+++ b/content/en/platform/corda/5.0/key-concepts/fundamentals/ledger/vault/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Vault"
 date: 2023-06-08
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-fundamentals-ledger-vault

--- a/content/en/platform/corda/5.0/key-concepts/fundamentals/privacy/_index.md
+++ b/content/en/platform/corda/5.0/key-concepts/fundamentals/privacy/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Privacy"
 date: 2023-06-07
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-fundamentals-privacy

--- a/content/en/platform/corda/5.0/reference/_index.md
+++ b/content/en/platform/corda/5.0/reference/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "References"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 date: 2023-04-24
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/reference/corda-cli/_index.md
+++ b/content/en/platform/corda/5.0/reference/corda-cli/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Corda CLI Commands"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 date: 2023-04-24
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/reference/corda-cli/database.md
+++ b/content/en/platform/corda/5.0/reference/corda-cli/database.md
@@ -1,6 +1,6 @@
 ---
 date: '2022-12-20'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-cordacli-database

--- a/content/en/platform/corda/5.0/reference/corda-cli/initial-config.md
+++ b/content/en/platform/corda/5.0/reference/corda-cli/initial-config.md
@@ -1,6 +1,6 @@
 ---
 date: '2022-12-20'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-cordacli-initial-config

--- a/content/en/platform/corda/5.0/reference/corda-cli/mgm.md
+++ b/content/en/platform/corda/5.0/reference/corda-cli/mgm.md
@@ -1,6 +1,6 @@
 ---
 date: '2022-12-20'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-cordacli-mgm

--- a/content/en/platform/corda/5.0/reference/corda-cli/package.md
+++ b/content/en/platform/corda/5.0/reference/corda-cli/package.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-01-06'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-cordacli-develop-commands

--- a/content/en/platform/corda/5.0/reference/corda-cli/secret-config.md
+++ b/content/en/platform/corda/5.0/reference/corda-cli/secret-config.md
@@ -1,6 +1,6 @@
 ---
 date: '2023-05-12'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-cordacli-secret-config

--- a/content/en/platform/corda/5.0/reference/corda-cli/topic.md
+++ b/content/en/platform/corda/5.0/reference/corda-cli/topic.md
@@ -1,6 +1,6 @@
 ---
 date: '2022-12-20'
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 menu:
   corda5:
     identifier: corda5-cordacli-topic

--- a/content/en/platform/corda/5.0/reference/rest-api/_index.md
+++ b/content/en/platform/corda/5.0/reference/rest-api/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Corda REST API"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 date: 2023-05-08
 menu:
   corda5:

--- a/content/en/platform/corda/5.0/reference/rest-api/accessing.md
+++ b/content/en/platform/corda/5.0/reference/rest-api/accessing.md
@@ -1,7 +1,7 @@
 ---
 title: "Accessing the REST API"
 project: corda
-version: 'Corda 5.0'
+version: 'Corda 5.0 Beta 4'
 date: 2023-05-08
 menu:
   corda5:

--- a/themes/doks/layouts/_default/_markup/render-heading.html
+++ b/themes/doks/layouts/_default/_markup/render-heading.html
@@ -20,7 +20,7 @@
   }
 </script>
 
-{{ if ne .Page.Params.version "Corda 5.0" }}
+{{ if ne .Page.Params.version "Corda 5.0 Beta 4" }}
   {{ if ne .Level 1 }}
     <h{{ .Level }} id="{{ .Anchor | safeURL }}"  class="link-heading">
       <a href="#{{ .Anchor | safeURL }}">

--- a/themes/doks/layouts/_default/list.html
+++ b/themes/doks/layouts/_default/list.html
@@ -21,7 +21,7 @@
 				</nav>
 			{{ end }}
 			{{ end }}
-			{{ if ne .Page.Params.version "Corda 5.0"}}			
+			{{ if ne .Page.Params.version "Corda 5.0 Beta 4"}}			
     			<h1>{{ .Title }}</h1>
 			{{ end }}
       {{ if .Site.Params.editPage -}}

--- a/themes/doks/layouts/_default/single.html
+++ b/themes/doks/layouts/_default/single.html
@@ -9,12 +9,12 @@
       </div>
 		</div>
     {{ end -}}
-		{{ if ne .Parent.Page.Params.version "Corda 5.0" }}
+		{{ if ne .Parent.Page.Params.version "Corda 5.0 Beta 4" }}
 			<nav class="docs-toc d-none d-xl-block col-xl-3" aria-label="Secondary navigation">
 				{{ partial "sidebar/docs-toc.html" . }}
 			</nav>
 		{{ end -}}
-		{{ if ne .Parent.Page.Params.version "Corda 5.0"}}
+		{{ if ne .Parent.Page.Params.version "Corda 5.0 Beta 4"}}
 			<main class="docs-content col-lg-11 col-xl-9 mx-lg-auto">
 		{{ else -}}
 			<main class="docs-content col-lg-11 col-xl-12 mx-lg-auto">
@@ -28,7 +28,7 @@
 					</ol>
 				</nav>
 			{{ end }}
-			{{ if ne .Parent.Page.Params.version "Corda 5.0"}}			
+			{{ if ne .Parent.Page.Params.version "Corda 5.0 Beta 4"}}			
     			<h1>{{ .Title }}</h1>
 			{{ end }}
       {{ if .Site.Params.editPage -}}

--- a/themes/doks/layouts/partials/head/script-header.html
+++ b/themes/doks/layouts/partials/head/script-header.html
@@ -8,7 +8,7 @@
 
     {{ if eq .IsHome true }}
       window.facetFilters = [
-        ['project:get-started', 'project:tutorials', 'project:samples', 'project:tools', 'project:announcements', 'version:Community Edition 4.10', 'version:Enterprise 4.10', 'version:CENM 1.5', 'version:Corda 5.0'],
+        ['project:get-started', 'project:tutorials', 'project:samples', 'project:tools', 'project:announcements', 'version:Community Edition 4.10', 'version:Enterprise 4.10', 'version:CENM 1.5', 'version:Corda 5.0 Beta 4'],
         'language:en'
       ];
 
@@ -16,7 +16,7 @@
       {{ $project := .Page.Params.project}}
       window.facetFilters = [
         ['project:{{- $project -}}'],
-        ['version:Community Edition 4.10', 'version:Enterprise 4.10', 'version:CENM 1.5', 'version:Corda 5.0'],
+        ['version:Community Edition 4.10', 'version:Enterprise 4.10', 'version:CENM 1.5', 'version:Corda 5.0 Beta 4'],
         'language:en'
       ];
     {{ else if eq .Page.Params.version nil }}

--- a/themes/doks/layouts/shortcodes/figure.html
+++ b/themes/doks/layouts/shortcodes/figure.html
@@ -28,7 +28,7 @@
     <img
     {{if $image }}
         src="{{ $image.RelPermalink }}"
-    {{ else if or (ne .Page.Params.version "Corda 5.0") (eq (.Page.Resources.GetMatch $src) true) }}
+    {{ else if or (ne .Page.Params.version "Corda 5.0 Beta 4") (eq (.Page.Resources.GetMatch $src) true) }}
         src="{{$src}}" 
     {{ else }}	 
       {{ errorf "Image not found: %q" $src "in" $.Page}}


### PR DESCRIPTION
Searches performed from C5 Beta 4 landing page only search on that page:
![image](https://github.com/corda/corda-docs-portal/assets/103633799/b255a2af-9f5b-4f57-845f-7bc73f7a4289)

This is because the "version" value used on the landing page was "Corda 5.0 Beta 4" but on all other C5 content pages was "Corda 5.0".

Could not update the landing page value as this is the value used in the version drop-down menu. This PR updates all other C5 content pages to "Corda 5.0 Beta 4" and also updates the algolia filter and various style and formatting checks.
