### PR TITLE
FE-91: Added tooltip for menu with sub-pages.

### DIFF
--- a/themes/doks/layouts/partials/sidebar/pages_in_version_menu.html
+++ b/themes/doks/layouts/partials/sidebar/pages_in_version_menu.html
@@ -23,7 +23,7 @@
                 data-bs-target='#{{ .Identifier }}'
                 aria-expanded="false"
                 aria-controls='{{ .Identifier }}'>
-          <span {{ if .URL }} onclick="window.location.href = {{ .URL }}" {{end}}>{{ .Pre }} {{ .Name }}</span>
+          <span title="{{ .Name }}" {{ if .URL }} onclick="window.location.href = {{ .URL }}" {{end}}>{{ .Pre }} {{ .Name }}</span>
         </button>
 
         <div class="collapse {{ if $page.HasMenuCurrent $sectionMenuForThisPage . }}show{{ end }} {{ if eq $currentURL .URL }}show{{ end }}" id='{{ .Identifier }}'>


### PR DESCRIPTION
Previous PR (https://github.com/corda/corda-docs-portal/pull/1491) only add a tooltip to the menu without children.

As Nadine suggested, it would be helpful to add a tooltip to all menu items, even the ones with a sub-menu.
 
<img width="432" alt="image" src="https://github.com/corda/corda-docs-portal/assets/80267895/5d28981f-b094-4c19-9f52-85dc3ff99bef">
