### PR TITLE
DOC-5561

### DIFF
--- a/content/en/platform/corda/5.0/developing-applications/getting-started/cordapp-standard-development-environment/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/getting-started/cordapp-standard-development-environment/_index.md
@@ -70,9 +70,9 @@ This section provides an overview of the content of CSDE. Other sections show yo
 On the left, you can see the folder structure created, ready for CorDapps development.
  {{< figure src="project-structure.png" figcaption="CSDE folder structure" alt="CSDE folders in IntelliJ" >}}
 
-For Kotlin, write your flow code in `workflows/src/main/kotlin/<your package path>` and your contract and states code in `/contracts/src/main/kotlin<your package path>`.
+For Kotlin, write your flow code in `workflows/src/main/kotlin/<your package path>` and your contract and states code in `/contracts/src/main/kotlin/<your package path>`.
 
-For Java, use `workflows/src/main/java/<your package path>` and your contract and states code in `/contracts/src/main/kotlin<your package path>`.
+For Java, use `workflows/src/main/java/<your package path>` and your contract and states code in `/contracts/src/main/java/<your package path>`.
 
 For test code, use the corresponding test folder.
 ### Gradle Helpers for the Combined Worker


### PR DESCRIPTION
- Updated file paths to include "/" between Kotlin and "your package path"

- Replaced reference to Kotlin in the Java contracts file path 