### PR TITLE
DOC-5576

### DIFF
--- a/content/en/platform/corda/5.0/developing-applications/getting-started/first-flow/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/getting-started/first-flow/_index.md
@@ -29,4 +29,4 @@ The use case in the example flows is very simple:
 
 The following sections describe the flow code in more detail:
 * [Kotlin Flow Code Walkthrough]({{< relref "code-kotlin.md" >}})
-{{< childpages >}}
+* [Java Flow Code Walkthrough]({{< relref "code-java.md" >}})

--- a/content/en/platform/corda/5.0/developing-applications/getting-started/first-flow/_index.md
+++ b/content/en/platform/corda/5.0/developing-applications/getting-started/first-flow/_index.md
@@ -28,5 +28,4 @@ The use case in the example flows is very simple:
 ## MyFirstFlow Code
 
 The following sections describe the flow code in more detail:
-* [Kotlin Flow Code Walkthrough]({{< relref "code-kotlin.md" >}})
-* [Java Flow Code Walkthrough]({{< relref "code-java.md" >}})
+{{< childpages >}}


### PR DESCRIPTION
The additional link to the Kotlin page came from a {{< childpages >}} shortcode below the Kotlin relref.

- Removed the child pages short code 
- Inserted a new relref to the Java Flow Code Walkthrough page

Building locally to test now.