### PR TITLE
single link format fix

### DIFF
--- a/content/en/tools/ledgergraph/ledgergraph-index.md
+++ b/content/en/tools/ledgergraph/ledgergraph-index.md
@@ -13,7 +13,7 @@ title: LedgerGraph
 
 **LedgerGraph** is a CorDapp you can use to get in-memory access to transaction data. Transaction information is kept in a graph structure on any node where **LedgerGraph** is installed. As not all transactions are related to all other transactions, there can actually be multiple components in the graph: each a **directed acyclic graph** (DAG).
 
-**LedgerGraph** enables other CorDapps, such as the set of [Collaborative Recovery CorDapps](..{{< relref "../../platform/corda/4.9/enterprise/node/collaborative-recovery/introduction-cr.md" >}}), to have near real-time access to data concerning all of a node's transactions and their relationships. Without it, many operations would be unacceptably slow and impractical.
+**LedgerGraph** enables other CorDapps, such as the set of [Collaborative Recovery CorDapps]({{< relref "../../platform/corda/4.9/enterprise/node/collaborative-recovery/introduction-cr.md" >}}), to have near real-time access to data concerning all of a node's transactions and their relationships. Without it, many operations would be unacceptably slow and impractical.
 
 {{< warning >}}
 LedgerGraph is a dependency for the set of Collaborative Recovery CorDapps V1.1 and above. If you are using an earlier version of Collaborative Recovery, you should not install the stand-alone LedgerGraph.


### PR DESCRIPTION
1. Multiple regex expressions tested to try to identify links missed. 
2. All .md links (./ and ../) are now changed to new format (with or without # tag).
3. Only one link error spotted that had been previously formatted wrongly. This is now fixed.

Only relative links ending in .html (with and without tags) to be changed now.