### PR TITLE
DOC-5654 - in reference to the Corda 4 API, changed 'backwards compat…

### DIFF
--- a/content/en/archived-docs/corda-os/4.7/api-stability-guarantees.md
+++ b/content/en/archived-docs/corda-os/4.7/api-stability-guarantees.md
@@ -20,18 +20,15 @@ title: API stability guarantees
 
 # API stability guarantees
 
-Corda makes certain commitments about what parts of the API will preserve backwards compatibility as they change and
-which will not. Over time, more of the API will fall under the stability guarantees. Thus, APIs can be categorized in the following 2 broad categories:
+Corda makes certain commitments about what parts of the Corda 4 API will preserve stability as they change and
+which will not. Over time, more of the Corda 4 API will fall under the stability guarantees. Thus, APIs can be categorized in the following 2 broad categories:
 
-
-* **public APIs**, for which API/[ABI](https://en.wikipedia.org/wiki/Application_binary_interface) backwards compatibility guarantees are provided. See: [Public API](#public-api)
-* **non-public APIs**, for which no backwards compatibility guarantees are provided. See: [Non-public API (experimental)](#non-public-api)
-
-
+* **public APIs**, for which API/[ABI](https://en.wikipedia.org/wiki/Application_binary_interface) stability guarantees are provided. See: [Public API](#public-api)
+* **non-public APIs**, for which no stability guarantees are provided. See: [Non-public API (experimental)](#non-public-api)
 
 # Public API
 
-The following modules form part of Corda’s public API and we commit to API/ABI backwards compatibility in following releases, unless an incompatible change is required for security reasons:
+The following modules form part of the Corda 4 public API and we commit to API/ABI stability in following releases, unless an incompatible change is required for security reasons:
 
 
 * **Core (net.corda.core)**: core Corda libraries such as crypto functions, types for Corda’s building blocks: states, contracts, transactions, attachments, etc. and some interfaces for nodes and protocols
@@ -51,7 +48,7 @@ has a stable API.
 
 # Non-public API (experimental)
 
-The following are not part of the Corda’s public API and no backwards compatibility guarantees are provided:
+The following are not part of the the Corda 4 public API and no stability guarantees are provided:
 
 
 * Incubating modules, for which we will do our best to minimise disruption to developers using them until we are able to graduate them into the public API

--- a/content/en/archived-docs/corda-os/4.8/api-stability-guarantees.md
+++ b/content/en/archived-docs/corda-os/4.8/api-stability-guarantees.md
@@ -20,18 +20,14 @@ title: API stability guarantees
 
 # API stability guarantees
 
-Corda makes certain commitments about what parts of the API will preserve backwards compatibility as they change and
-which will not. Over time, more of the API will fall under the stability guarantees. Thus, APIs can be categorized in the following 2 broad categories:
+Corda makes certain commitments about which parts of the Corda 4 API will remain stable and which will not. Over time, more of the API will fall under the stability guarantees. Thus, APIs can be categorized in the following 2 broad categories:
 
-
-* **public APIs**, for which API/[ABI](https://en.wikipedia.org/wiki/Application_binary_interface) backwards compatibility guarantees are provided. See: [Public API](#public-api)
-* **non-public APIs**, for which no backwards compatibility guarantees are provided. See: [Non-public API (experimental)](#non-public-api-experimental)
-
-
+* **public APIs**, for which API/[ABI](https://en.wikipedia.org/wiki/Application_binary_interface) stability guarantees are provided. See: [Public API](#public-api)
+* **non-public APIs**, for which no stability guarantees are provided. See: [Non-public API (experimental)](#non-public-api-experimental)
 
 # Public API
 
-The following modules form part of Corda’s public API and we commit to API/ABI backwards compatibility in following releases, unless an incompatible change is required for security reasons:
+The following modules form part of the Corda 4 public API and we commit to API/ABI stability in following releases, unless an incompatible change is required for security reasons:
 
 
 * **Core (net.corda.core)**: core Corda libraries such as crypto functions, types for Corda’s building blocks: states, contracts, transactions, attachments, etc. and some interfaces for nodes and protocols
@@ -47,12 +43,9 @@ The following modules form part of Corda’s public API and we commit to API/ABI
 Additionally, the **Tokens SDK (com.r3.corda.lib.tokens)** available in [the Tokens GitHub repository](https://github.com/corda/token-sdk)
 has a stable API.
 
-
-
 # Non-public API (experimental)
 
-The following are not part of the Corda’s public API and no backwards compatibility guarantees are provided:
-
+The following are not part of the Corda 4 public API and no stability guarantees are provided:
 
 * Incubating modules, for which we will do our best to minimise disruption to developers using them until we are able to graduate them into the public API
 * Internal modules, which are not to be used, and will change without notice
@@ -61,7 +54,7 @@ not be used)
 * Any interfaces, classes or methods whose name contains the word `internal` or `Internal`
 
 The **finance module** was the first CorDapp ever written and is a legacy module. Although it is not a part of our API guarantees, we also
-don’t anticipate much future change to it. Users should use the tokens SDK instead.
+don’t anticipate much future change to it. Users should use the Tokens SDK instead.
 
 
 ## Corda incubating modules

--- a/content/en/platform/corda/4.10/community/api-stability-guarantees.md
+++ b/content/en/platform/corda/4.10/community/api-stability-guarantees.md
@@ -20,18 +20,16 @@ title: API stability guarantees
 
 # API stability guarantees
 
-Corda makes certain commitments about what parts of the API will preserve backwards compatibility as they change and
+Corda makes certain commitments about what parts of the Corda 4 API will preserve stability as they change and
 which will not. Over time, more of the API will fall under the stability guarantees. Thus, APIs can be categorized in the following 2 broad categories:
 
 
-* **public APIs**, for which API/[ABI](https://en.wikipedia.org/wiki/Application_binary_interface) backwards compatibility guarantees are provided. See: [Public API](#public-api)
-* **non-public APIs**, for which no backwards compatibility guarantees are provided. See: [Non-public API (experimental)](#non-public-api-experimental)
-
-
+* **public APIs**, for which API/[ABI](https://en.wikipedia.org/wiki/Application_binary_interface) stability guarantees are provided. See: [Public API](#public-api)
+* **non-public APIs**, for which no stability guarantees are provided. See: [Non-public API (experimental)](#non-public-api-experimental)
 
 # Public API
 
-The following modules form part of Corda’s public API and we commit to API/ABI backwards compatibility in following releases, unless an incompatible change is required for security reasons:
+The following modules form part of the Corda 4 public API and we commit to API/ABI stability in following releases, unless an incompatible change is required for security reasons:
 
 
 * **Core (net.corda.core)**: core Corda libraries such as crypto functions, types for Corda’s building blocks: states, contracts, transactions, attachments, etc. and some interfaces for nodes and protocols
@@ -47,11 +45,9 @@ The following modules form part of Corda’s public API and we commit to API/ABI
 Additionally, the **Tokens SDK (com.r3.corda.lib.tokens)** available in [the Tokens GitHub repository](https://github.com/corda/token-sdk)
 has a stable API.
 
-
-
 # Non-public API (experimental)
 
-The following are not part of the Corda’s public API and no backwards compatibility guarantees are provided:
+The following are not part of the Corda 4 public API and no stability guarantees are provided:
 
 
 * Incubating modules, for which we will do our best to minimise disruption to developers using them until we are able to graduate them into the public API

--- a/content/en/platform/corda/4.10/community/app-upgrade-notes.md
+++ b/content/en/platform/corda/4.10/community/app-upgrade-notes.md
@@ -18,7 +18,7 @@ title: Upgrading CorDapps to newer platform versions
 
 # Upgrading CorDapps to newer platform versions
 
-These notes provide information on upgrading your CorDapps from previous versions. Corda provides backwards compatibility for public,
+These notes provide information on upgrading your CorDapps from previous versions. Corda 4 provides stability for public,
 non-experimental APIs that have been committed to. A list can be found in the [API stability guarantees](api-stability-guarantees.md) page.
 
 This means that you can upgrade your node across versions *without recompiling or adjusting your CorDapps*. You just have to upgrade

--- a/content/en/platform/corda/4.10/enterprise/cordapps/api-stability-guarantees.md
+++ b/content/en/platform/corda/4.10/enterprise/cordapps/api-stability-guarantees.md
@@ -14,14 +14,14 @@ weight: 1
 
 # API stability guarantees
 
-Corda maintains the stability of specific APIs. APIs are categorized as:
+Corda maintains the stability of specific Corda 4 APIs. APIs are categorized as:
 
-* **Public APIs**, which are APIs/application binary interfaces (ABIs) that are backwards compatible. See [public API](#public-api) for more information.
-* **Non-public APIs**. These APIs are not guaranteed to be backwards compatible. See [non-public API (experimental)](#non-public-api-experimental) for more information.
+* **Public APIs**, which are APIs/application binary interfaces (ABIs) that are stable. See [public API](#public-api) for more information.
+* **Non-public APIs**. These APIs are not guaranteed to be stable. See [non-public API (experimental)](#non-public-api-experimental) for more information.
 
 ## Public API
 
-The following modules form part of Corda’s public API. These will be backwards compatible for future releases, unless an incompatible change is required for security reasons:
+The following modules form part of the Corda 4 public API. These will be stable for future releases, unless an incompatible change is required for security reasons:
 
 * **Core (net.corda.core)**: Core Corda libraries such as crypto functions, types for Corda’s building blocks (such as states, contracts, transactions, and attachments), and some interfaces for nodes and protocols.
 * **Client RPC (net.corda.client.rpc)**.
@@ -38,7 +38,7 @@ also has a stable API.
 
 ## Non-public API (experimental)
 
-Corda does *not* guarantee  backwards compatibility for:
+Corda does *not* guarantee stability for:
 
 * Incubating modules (where possible, disruption to developers will be minimized). See [Corda incubating modules](#corda-incubating-modules) for more information.
 * **The finance module**: a legacy module. Use the Tokens SDK `com.r3.corda.lib.tokens` (available in the [Tokens GitHub repository](https://github.com/corda/token-sdk) instead.
@@ -49,7 +49,6 @@ Do not use the following as they may be changed or deleted without notice.
 * Internal modules.
 * Package and/or sub-package containing `.internal` (for example, `net.corda.core.internal`).
 * Any interfaces, classes or methods whose name contains the word `internal` or `Internal`.
-
 {{< /warning >}}
 
 

--- a/content/en/platform/corda/4.10/enterprise/minor-version-node-upgrade.md
+++ b/content/en/platform/corda/4.10/enterprise/minor-version-node-upgrade.md
@@ -17,7 +17,7 @@ weight: 11
 
 Follow these steps to upgrade a node from Corda Enterprise Edition 4.10 to Corda Enterprise Edition 4.10.x.
 
-Most of Corda's public, non-experimental APIs are backwards compatible. See the [full list of stable APIs]({{< relref "../../../../api-ref/api-ref-corda-4.md" >}}). If you are working with a stable API, you don't need to update your CorDapps. To upgrade:
+Most of the Corda 4 public, non-experimental APIs are stable. See the [full list of stable APIs]({{< relref "../../../../api-ref/api-ref-corda-4.md" >}}). If you are working with a stable API, you don't need to update your CorDapps. To upgrade:
 
 1. [Drain the node](#step-1-drain-the-node).
 2. <a href="#step-2-replace-cordajar-with-the-new-version">Replace the `corda.jar` file with the new version.</a>

--- a/content/en/platform/corda/4.10/enterprise/node-upgrade-notes.md
+++ b/content/en/platform/corda/4.10/enterprise/node-upgrade-notes.md
@@ -27,7 +27,7 @@ If you are upgrading from Corda Enterprise 3.x, you must first:
 Corda Enterprise Edition 4.10 fixes a security vulnerability in the JPA notary. Before upgrading to Corda Enterprise Edition 4.10, read the guidance on [upgrading your notary service](notary/upgrading-the-ha-notary-service.md).
 {{< /warning >}}
 
-Most of Corda's public, non-experimental APIs are backwards compatible. See the [full list of stable APIs]({{< relref "../../../../api-ref/api-ref-corda-4.md" >}}). If you are working with a stable API, you don't need to update your CorDapps. To upgrade:
+Most of the Corda 4 public, non-experimental APIs are stable. See the [full list of stable APIs]({{< relref "../../../../api-ref/api-ref-corda-4.md" >}}). If you are working with a stable API, you don't need to update your CorDapps. To upgrade:
 
 1. [Drain the node](#step-1-drain-the-node).
 2. [Make a backup of the directories in your node and database](#step-2-make-a-backup-of-your-nodes-directories-and-database).

--- a/content/en/platform/corda/4.7/enterprise/app-upgrade-notes.md
+++ b/content/en/platform/corda/4.7/enterprise/app-upgrade-notes.md
@@ -18,8 +18,8 @@ weight: 30
 Corda Enterprise Edition 4.7.1 fixes a security vulnerability in the JPA notary. Before upgrading to Corda Enterprise Edition 4.7.1 please read the guidance on [upgrading your notary service]({{< relref "../../../../../en/platform/corda/4.7/enterprise/notary/upgrading-the-ha-notary-service.md" >}}).
 {{< /warning >}}
 
-These notes provide instructions for upgrading your CorDapps from previous versions. Corda provides backwards compatibility for public,
-non-experimental APIs that have been committed to. A list can be found in the api-stability-guarantees page.
+These notes provide instructions for upgrading your CorDapps from previous versions. Corda 4 provides stability for public,
+non-experimental APIs that have been committed to. A list can be found in [API Stability Guarantees]({{< relref "cordapps/api-stability-guarantees.md" >}}).
 
 This means that you can upgrade your node across versions *without recompiling or adjusting your CorDapps*. You just have to upgrade
 your node and restart.

--- a/content/en/platform/corda/4.7/enterprise/cordapps/api-stability-guarantees.md
+++ b/content/en/platform/corda/4.7/enterprise/cordapps/api-stability-guarantees.md
@@ -14,18 +14,17 @@ weight: 1
 
 # API stability guarantees
 
-Corda makes certain commitments about what parts of the API will preserve backwards compatibility as they change and
-which will not. Over time, more of the API will fall under the stability guarantees. Thus, APIs can be categorized in the following 2 broad categories:
+Corda makes certain commitments about what parts of the Corda 4 API will preserve stability as they change and
+which will not. Over time, more of the Corda 4 API will fall under the stability guarantees. Thus, APIs can be categorized in the following 2 broad categories:
 
 
-* **public APIs**, for which API/[ABI](https://en.wikipedia.org/wiki/Application_binary_interface) backwards compatibility guarantees are provided. See: [Public API](#public-api)
-* **non-public APIs**, for which no backwards compatibility guarantees are provided. See: [Non-public API (experimental)](#non-public-api)
-
+* **public APIs**, for which API/[ABI](https://en.wikipedia.org/wiki/Application_binary_interface) stability guarantees are provided. See: [Public API](#public-api)
+* **non-public APIs**, for which no stability guarantees are provided. See: [Non-public API (experimental)](#non-public-api)
 
 
 ## Public API
 
-The following modules form part of Corda’s public API and we commit to API/ABI backwards compatibility in following releases, unless an incompatible change is required for security reasons:
+The following modules form part of the Corda 4 public API and we commit to API/ABI stability in following releases, unless an incompatible change is required for security reasons:
 
 
 * **Core (net.corda.core)**: core Corda libraries such as crypto functions, types for Corda’s building blocks: states, contracts, transactions, attachments, etc. and some interfaces for nodes and protocols
@@ -41,11 +40,9 @@ The following modules form part of Corda’s public API and we commit to API/ABI
 Additionally, the **Tokens SDK (com.r3.corda.lib.tokens)** available in [the Tokens GitHub repository](https://github.com/corda/token-sdk)
 has a stable API.
 
-
-
 ## Non-public API (experimental)
 
-The following are not part of the Corda’s public API and no backwards compatibility guarantees are provided:
+The following are not part of the the Corda 4 public API and no stability guarantees are provided:
 
 
 * Incubating modules, for which we will do our best to minimise disruption to developers using them until we are able to graduate them into the public API

--- a/content/en/platform/corda/4.7/enterprise/minor-version-node-upgrade.md
+++ b/content/en/platform/corda/4.7/enterprise/minor-version-node-upgrade.md
@@ -17,7 +17,7 @@ weight: 11
 
 Follow these steps to upgrade a node from Corda Enterprise Edition 4.7 to Corda Enterprise Edition 4.7.x.
 
-Most of Corda's public, non-experimental APIs are backwards compatible. See the [full list of stable APIs](cordapps/api-stability-guarantees.md). If you are working with a stable API, you don't need to update your CorDapps. To upgrade:
+Most of the Corda 4 public, non-experimental APIs are stable. See the [full list of stable APIs]({{< relref "cordapps/api-stability-guarantees.md" >}}). If you are working with a stable API, you don't need to update your CorDapps. To upgrade:
 
 1. [Drain the node](#step-1-drain-the-node).
 2. <a href="#step-2-replace-cordajar-with-the-new-version">Replace the `corda.jar` file with the new version.</a>

--- a/content/en/platform/corda/4.7/enterprise/node-operations-upgrade-cordapps.md
+++ b/content/en/platform/corda/4.7/enterprise/node-operations-upgrade-cordapps.md
@@ -20,7 +20,7 @@ changes have been made. These could range from database changes, to changes in t
 
 For developer information on upgrading CorDapps, see [Release new CorDapp versions](cordapps/upgrading-cordapps.md).
 
-To be compatible with Corda Enterprise, CorDapps need to bundle database migaration scripts (see [Database management scripts](cordapps/database-management.md)).
+To be compatible with Corda Enterprise, CorDapps need to bundle database migration scripts (see [Database management scripts](cordapps/database-management.md)).
 
 
 ## Flow upgrades

--- a/content/en/platform/corda/4.8/enterprise/app-upgrade-notes.md
+++ b/content/en/platform/corda/4.8/enterprise/app-upgrade-notes.md
@@ -21,7 +21,7 @@ Corda Enterprise Edition 4.8 fixes a security vulnerability in the JPA notary. B
 This guide shows you how to upgrade your CorDapp from previous platform versions to benefit
 from the new features in the latest release.
 
-Most of Corda's public, non-experimental APIs are backwards compatible. See the [full list of stable APIs](cordapps/api-stability-guarantees.html). If you are working with a stable API, you don't need to update your CorDapps. However, there are usually new features and other opt-in changes that may improve the security, performance, or usability of your
+Most of the Corda 4 public, non-experimental APIs are stable. See the [full list of stable APIs](cordapps/api-stability-guarantees.html). If you are working with a stable API, you don't need to update your CorDapps. However, there are usually new features and other opt-in changes that may improve the security, performance, or usability of your
 CorDapp that are worth considering for any actively maintained software.
 
 

--- a/content/en/platform/corda/4.8/enterprise/cordapps/api-stability-guarantees.md
+++ b/content/en/platform/corda/4.8/enterprise/cordapps/api-stability-guarantees.md
@@ -14,14 +14,14 @@ weight: 1
 
 # API stability guarantees
 
-Corda maintains the stability of specific APIs. APIs are categorized as:
+Corda maintains the stability of specific Corda 4 APIs. APIs are categorized as:
 
-* **Public APIs**, which are APIs/application binary interfaces (ABIs) that are backwards compatible. See [public API](#public-api) for more information.
-* **Non-public APIs**. These APIs are not guaranteed to be backwards compatible. See [non-public API (experimental)](#non-public-api-experimental) for more information.
+* **Public APIs**, which are APIs/application binary interfaces (ABIs) that are stable. See [public API](#public-api) for more information.
+* **Non-public APIs**. These APIs are not guaranteed to be stable. See [non-public API (experimental)](#non-public-api-experimental) for more information.
 
 ## Public API
 
-The following modules form part of Corda’s public API. These will be backwards compatible for future releases, unless an incompatible change is required for security reasons:
+The following modules form part of the Corda 4 public API. These will be stable for future releases, unless an incompatible change is required for security reasons:
 
 * **Core (net.corda.core)**: Core Corda libraries such as crypto functions, types for Corda’s building blocks (such as states, contracts, transactions, and attachments), and some interfaces for nodes and protocols.
 * **Client RPC (net.corda.client.rpc)**.
@@ -38,14 +38,15 @@ also has a stable API.
 
 ## Non-public API (experimental)
 
-Corda does *not* guarantee  backwards compatibility for:
+Corda does *not* guarantee stability for:
 
 * Incubating modules (where possible, disruption to developers will be minimized). See [Corda incubating modules](#corda-incubating-modules) for more information.
 * **The finance module**: a legacy module. Use the Tokens SDK `com.r3.corda.lib.tokens` (available in the [Tokens GitHub repository](https://github.com/corda/token-sdk) instead.
 
 {{< warning >}}
 
-Do not use the following as they may be changed or deleted without notice.
+Do not use the following as they may be changed or deleted without notice:
+
 * Internal modules.
 * Package and/or sub-package containing `.internal` (for example, `net.corda.core.internal`).
 * Any interfaces, classes or methods whose name contains the word `internal` or `Internal`.

--- a/content/en/platform/corda/4.8/enterprise/minor-version-node-upgrade.md
+++ b/content/en/platform/corda/4.8/enterprise/minor-version-node-upgrade.md
@@ -17,7 +17,7 @@ weight: 11
 
 Follow these steps to upgrade a node from Corda Enterprise Edition 4.8 to Corda Enterprise Edition 4.8.x.
 
-Most of Corda's public, non-experimental APIs are backwards compatible. See the [full list of stable APIs](cordapps/api-stability-guarantees.md). If you are working with a stable API, you don't need to update your CorDapps. To upgrade:
+Most of the Corda 4 public, non-experimental APIs are stable. See the [full list of stable APIs](cordapps/api-stability-guarantees.md). If you are working with a stable API, you don't need to update your CorDapps. To upgrade:
 
 1. [Drain the node](#step-1-drain-the-node).
 2. <a href="#step-2-replace-cordajar-with-the-new-version">Replace the `corda.jar` file with the new version.</a>

--- a/content/en/platform/corda/4.8/enterprise/node-upgrade-notes.md
+++ b/content/en/platform/corda/4.8/enterprise/node-upgrade-notes.md
@@ -27,7 +27,7 @@ If you are upgrading from Corda Enterprise 3.x, you must first:
 Corda Enterprise Edition 4.8 fixes a security vulnerability in the JPA notary. Before upgrading to Corda Enterprise Edition 4.8, read the guidance on [upgrading your notary service](notary/upgrading-the-ha-notary-service.md).
 {{< /warning >}}
 
-Most of Corda's public, non-experimental APIs are backwards compatible. See the [full list of stable APIs](cordapps/api-stability-guarantees.md). If you are working with a stable API, you don't need to update your CorDapps. To upgrade:
+Most of the Corda 4 public, non-experimental APIs are stable. See the [full list of stable APIs](cordapps/api-stability-guarantees.md). If you are working with a stable API, you don't need to update your CorDapps. To upgrade:
 
 1. [Drain the node](#step-1-drain-the-node).
 2. [Make a backup of the directories in your node and database](#step-2-make-a-backup-of-your-nodes-directories-and-database).

--- a/content/en/platform/corda/4.9/community/api-stability-guarantees.md
+++ b/content/en/platform/corda/4.9/community/api-stability-guarantees.md
@@ -20,18 +20,16 @@ title: API stability guarantees
 
 # API stability guarantees
 
-Corda makes certain commitments about what parts of the API will preserve backwards compatibility as they change and
-which will not. Over time, more of the API will fall under the stability guarantees. Thus, APIs can be categorized in the following 2 broad categories:
+Corda makes certain commitments about what parts of the Corda 4 API will preserve stability as they change and
+which will not. Over time, more of the Corda 4 API will fall under the stability guarantees. Thus, APIs can be categorized in the following 2 broad categories:
 
 
-* **public APIs**, for which API/[ABI](https://en.wikipedia.org/wiki/Application_binary_interface) backwards compatibility guarantees are provided. See: [Public API](#public-api)
-* **non-public APIs**, for which no backwards compatibility guarantees are provided. See: [Non-public API (experimental)](#non-public-api-experimental)
-
-
+* **public APIs**, for which API/[ABI](https://en.wikipedia.org/wiki/Application_binary_interface) stability guarantees are provided. See: [Public API](#public-api)
+* **non-public APIs**, for which no stability guarantees are provided. See: [Non-public API (experimental)](#non-public-api-experimental)
 
 # Public API
 
-The following modules form part of Corda’s public API and we commit to API/ABI backwards compatibility in following releases, unless an incompatible change is required for security reasons:
+The following modules form part of the Corda 4 public API and we commit to API/ABI stability in following releases, unless an incompatible change is required for security reasons:
 
 
 * **Core (net.corda.core)**: core Corda libraries such as crypto functions, types for Corda’s building blocks: states, contracts, transactions, attachments, etc. and some interfaces for nodes and protocols
@@ -47,12 +45,9 @@ The following modules form part of Corda’s public API and we commit to API/ABI
 Additionally, the **Tokens SDK (com.r3.corda.lib.tokens)** available in [the Tokens GitHub repository](https://github.com/corda/token-sdk)
 has a stable API.
 
-
-
 # Non-public API (experimental)
 
-The following are not part of the Corda’s public API and no backwards compatibility guarantees are provided:
-
+The following are not part of the Corda 4 public API and no stability guarantees are provided:
 
 * Incubating modules, for which we will do our best to minimise disruption to developers using them until we are able to graduate them into the public API
 * Internal modules, which are not to be used, and will change without notice

--- a/content/en/platform/corda/4.9/enterprise/app-upgrade-notes.md
+++ b/content/en/platform/corda/4.9/enterprise/app-upgrade-notes.md
@@ -21,7 +21,7 @@ Corda Enterprise Edition 4.9 fixes a security vulnerability in the JPA notary. B
 This guide shows you how to upgrade your CorDapp from previous platform versions to benefit
 from the new features in the latest release.
 
-Most of Corda's public, non-experimental APIs are backwards compatible. See the [full list of stable APIs]({{< relref "../../../../api-ref/api-ref-corda-4.md" >}}). If you are working with a stable API, you don't need to update your CorDapps. However, there are usually new features and other opt-in changes that may improve the security, performance, or usability of your CorDapp that are worth considering for any actively maintained software.
+Most of the Corda 4 public, non-experimental APIs are stable. See the [full list of stable APIs]({{< relref "../../../../api-ref/api-ref-corda-4.md" >}}). If you are working with a stable API, you don't need to update your CorDapps. However, there are usually new features and other opt-in changes that may improve the security, performance, or usability of your CorDapp that are worth considering for any actively maintained software.
 
 
 {{< warning >}}

--- a/content/en/platform/corda/4.9/enterprise/cordapps/api-stability-guarantees.md
+++ b/content/en/platform/corda/4.9/enterprise/cordapps/api-stability-guarantees.md
@@ -14,14 +14,14 @@ weight: 1
 
 # API stability guarantees
 
-Corda maintains the stability of specific APIs. APIs are categorized as:
+Corda maintains the stability of specific Corda 4 APIs. APIs are categorized as:
 
-* **Public APIs**, which are APIs/application binary interfaces (ABIs) that are backwards compatible. See [public API](#public-api) for more information.
-* **Non-public APIs**. These APIs are not guaranteed to be backwards compatible. See [non-public API (experimental)](#non-public-api-experimental) for more information.
+* **Public APIs**, which are APIs/application binary interfaces (ABIs) that are stable. See [public API](#public-api) for more information.
+* **Non-public APIs**. These APIs are not guaranteed to be stable. See [non-public API (experimental)](#non-public-api-experimental) for more information.
 
 ## Public API
 
-The following modules form part of Corda’s public API. These will be backwards compatible for future releases, unless an incompatible change is required for security reasons:
+The following modules form part of the Corda 4 public API. These will be stable for future releases, unless an incompatible change is required for security reasons:
 
 * **Core (net.corda.core)**: Core Corda libraries such as crypto functions, types for Corda’s building blocks (such as states, contracts, transactions, and attachments), and some interfaces for nodes and protocols.
 * **Client RPC (net.corda.client.rpc)**.
@@ -38,14 +38,15 @@ also has a stable API.
 
 ## Non-public API (experimental)
 
-Corda does *not* guarantee  backwards compatibility for:
+Corda does *not* guarantee stability for:
 
 * Incubating modules (where possible, disruption to developers will be minimized). See [Corda incubating modules](#corda-incubating-modules) for more information.
 * **The finance module**: a legacy module. Use the Tokens SDK `com.r3.corda.lib.tokens` (available in the [Tokens GitHub repository](https://github.com/corda/token-sdk) instead.
 
 {{< warning >}}
 
-Do not use the following as they may be changed or deleted without notice.
+Do not use the following as they may be changed or deleted without notice:
+
 * Internal modules.
 * Package and/or sub-package containing `.internal` (for example, `net.corda.core.internal`).
 * Any interfaces, classes or methods whose name contains the word `internal` or `Internal`.

--- a/content/en/platform/corda/4.9/enterprise/minor-version-node-upgrade.md
+++ b/content/en/platform/corda/4.9/enterprise/minor-version-node-upgrade.md
@@ -17,7 +17,7 @@ weight: 11
 
 Follow these steps to upgrade a node from Corda Enterprise Edition 4.9 to Corda Enterprise Edition 4.9.x.
 
-Most of Corda's public, non-experimental APIs are backwards compatible. See the [full list of stable APIs]({{< relref "../../../../api-ref/api-ref-corda-4.md" >}}). If you are working with a stable API, you don't need to update your CorDapps. To upgrade:
+Most of the Corda 4 public, non-experimental APIs are stable. See the [full list of stable APIs]({{< relref "../../../../api-ref/api-ref-corda-4.md" >}}). If you are working with a stable API, you don't need to update your CorDapps. To upgrade:
 
 1. [Drain the node](#step-1-drain-the-node).
 2. <a href="#step-2-replace-cordajar-with-the-new-version">Replace the `corda.jar` file with the new version.</a>

--- a/content/en/platform/corda/4.9/enterprise/node-upgrade-notes.md
+++ b/content/en/platform/corda/4.9/enterprise/node-upgrade-notes.md
@@ -27,7 +27,7 @@ If you are upgrading from Corda Enterprise 3.x, you must first:
 Corda Enterprise Edition 4.9 fixes a security vulnerability in the JPA notary. Before upgrading to Corda Enterprise Edition 4.9, read the guidance on [upgrading your notary service](notary/upgrading-the-ha-notary-service.md).
 {{< /warning >}}
 
-Most of Corda's public, non-experimental APIs are backwards compatible. See the [full list of stable APIs]({{< relref "../../../../api-ref/api-ref-corda-4.md" >}}). If you are working with a stable API, you don't need to update your CorDapps. To upgrade:
+Most of the Corda 4 public, non-experimental APIs are stable. See the [full list of stable APIs]({{< relref "../../../../api-ref/api-ref-corda-4.md" >}}). If you are working with a stable API, you don't need to update your CorDapps. To upgrade:
 
 1. [Drain the node](#step-1-drain-the-node).
 2. [Make a backup of the directories in your node and database](#step-2-make-a-backup-of-your-nodes-directories-and-database).


### PR DESCRIPTION
…ibility' and similar to 'stability' and similar. Also changed references to Corda API to Corda 4 API, to make it clear stability only applies within that and not to Corda 5 as well.