### PR TITLE
Update figure error message

### DIFF
--- a/themes/doks/layouts/shortcodes/figure.html
+++ b/themes/doks/layouts/shortcodes/figure.html
@@ -31,7 +31,7 @@
     {{ else if or (ne .Page.Params.version "Corda 5.0") (eq (.Page.Resources.GetMatch $src) true) }}
         src="{{$src}}" 
     {{ else }}	 
-      {{ errorf "Image not found: %q" $src "in" $.Page}}
+        {{ errorf "Image not found: %q in %s" $src .Position }}
     {{ end }}
     alt="{{$alt}}"
     {{if $title }} 


### PR DESCRIPTION
The error message when an image file is not found for the `figure` shortcode was badly formatted and did not include the position of the error.

Before:
 
![image](https://github.com/corda/corda-docs-portal/assets/103633799/330e3fcc-d0ca-4120-8c28-d4823edfb4f7)

After:

![image](https://github.com/corda/corda-docs-portal/assets/103633799/5fd9269f-6cef-4c18-bd54-d86631e4b9e1)
