### PR TITLE
DOC-5718 - fixed instances of wrong versions in docs.

### DIFF
--- a/content/en/platform/corda/4.10/community/api-identity.md
+++ b/content/en/platform/corda/4.10/community/api-identity.md
@@ -106,7 +106,7 @@ override fun call(): SignedTransaction {
 
 
 
-[TwoPartyDealFlow.kt](https://github.com/corda/corda/blob/release/os/4.8/finance/workflows/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt) | ![github](/images/svg/github.svg "github")
+[TwoPartyDealFlow.kt](https://github.com/corda/corda/blob/release/os/4.10/finance/workflows/src/main/kotlin/net/corda/finance/flows/TwoPartyDealFlow.kt) | ![github](/images/svg/github.svg "github")
 
 {{< /tabs >}}
 
@@ -161,7 +161,7 @@ val twiceSignedTx = partSignedTx + sellerSignature
 
 
 
-[TwoPartyTradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.8/finance/workflows/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt) | ![github](/images/svg/github.svg "github")
+[TwoPartyTradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.10/finance/workflows/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt) | ![github](/images/svg/github.svg "github")
 
 {{< /tabs >}}
 
@@ -201,7 +201,7 @@ subFlow(IdentitySyncFlow.Receive(otherSideSession))
 
 
 
-[TwoPartyTradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.8/finance/workflows/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt) | ![github](/images/svg/github.svg "github")
+[TwoPartyTradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.10/finance/workflows/src/main/kotlin/net/corda/finance/flows/TwoPartyTradeFlow.kt) | ![github](/images/svg/github.svg "github")
 
 {{< /tabs >}}
 

--- a/content/en/platform/corda/4.10/community/api-persistence.md
+++ b/content/en/platform/corda/4.10/community/api-persistence.md
@@ -62,7 +62,7 @@ interface QueryableState : ContractState {
 
 ```
 
-[PersistentTypes.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/schemas/PersistentTypes.kt)
+[PersistentTypes.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/schemas/PersistentTypes.kt)
 
 The `QueryableState` interface requires the state to enumerate the different relational schemas it supports, for
 instance in situations where the schema has evolved. Each relational schema is represented as a `MappedSchema`
@@ -97,7 +97,7 @@ interface SchemaService {
 
 ```
 
-[SchemaService.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/main/kotlin/net/corda/node/services/api/SchemaService.kt)
+[SchemaService.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/main/kotlin/net/corda/node/services/api/SchemaService.kt)
 
 ```kotlin
 /**
@@ -144,7 +144,7 @@ open class MappedSchema(schemaFamily: Class<*>,
 
 ```
 
-[PersistentTypes.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/schemas/PersistentTypes.kt)
+[PersistentTypes.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/schemas/PersistentTypes.kt)
 
 With this framework, the relational view of ledger states can evolve in a controlled fashion in lock-step with internal systems or other
 integration points and is not dependant on changes to the contract code.
@@ -266,7 +266,7 @@ object CashSchemaV1 : MappedSchema(schemaFamily = CashSchema.javaClass, version 
 
 
 
-[CashSchemaV1.kt](https://github.com/corda/corda/blob/release/os/4.8/finance/contracts/src/main/kotlin/net/corda/finance/schemas/CashSchemaV1.kt) | ![github](/images/svg/github.svg "github")
+[CashSchemaV1.kt](https://github.com/corda/corda/blob/release/os/4.10/finance/contracts/src/main/kotlin/net/corda/finance/schemas/CashSchemaV1.kt) | ![github](/images/svg/github.svg "github")
 
 {{< /tabs >}}
 
@@ -365,7 +365,7 @@ database.transaction {
 }
 ```
 
-[HibernateConfigurationTest.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt)
+[HibernateConfigurationTest.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/persistence/HibernateConfigurationTest.kt)
 
 JDBC sessions can be used in flows and services (see “[Writing flows](api-flows.md)”).
 

--- a/content/en/platform/corda/4.10/community/api-transactions.md
+++ b/content/en/platform/corda/4.10/community/api-transactions.md
@@ -478,7 +478,7 @@ We can add components to the builder using the `TransactionBuilder.withItems` me
 
 
 
-[TransactionBuilder.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt) | ![github](/images/svg/github.svg "github")
+[TransactionBuilder.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/transactions/TransactionBuilder.kt) | ![github](/images/svg/github.svg "github")
 
 {{< /tabs >}}
 
@@ -788,7 +788,7 @@ data class SignedTransaction(val txBits: SerializedBytes<CoreTransaction>,
 
 
 
-[SignedTransaction.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt) | ![github](/images/svg/github.svg "github")
+[SignedTransaction.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/transactions/SignedTransaction.kt) | ![github](/images/svg/github.svg "github")
 
 {{< /tabs >}}
 

--- a/content/en/platform/corda/4.10/community/api-vault-query.md
+++ b/content/en/platform/corda/4.10/community/api-vault-query.md
@@ -87,7 +87,7 @@ fun <T : ContractState> _trackBy(criteria: QueryCriteria,
 
 ```
 
-[VaultService.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt)
+[VaultService.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt)
 
 And via `CordaRPCOps` for use by RPC client applications:
 
@@ -100,7 +100,7 @@ fun <T : ContractState> vaultQueryBy(criteria: QueryCriteria,
 
 ```
 
-[CordaRPCOps.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt)
+[CordaRPCOps.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt)
 
 ```kotlin
 @RPCReturnsObservables
@@ -111,7 +111,7 @@ fun <T : ContractState> vaultTrackBy(criteria: QueryCriteria,
 
 ```
 
-[CordaRPCOps.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt)
+[CordaRPCOps.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt)
 
 Helper methods are also provided with default values for arguments:
 
@@ -126,7 +126,7 @@ fun <T : ContractState> vaultQueryByWithSorting(contractStateType: Class<out T>,
 
 ```
 
-[CordaRPCOps.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt)
+[CordaRPCOps.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt)
 
 ```kotlin
 fun <T : ContractState> vaultTrack(contractStateType: Class<out T>): DataFeed<Vault.Page<T>, Vault.Update<T>>
@@ -139,7 +139,7 @@ fun <T : ContractState> vaultTrackByWithSorting(contractStateType: Class<out T>,
 
 ```
 
-[CordaRPCOps.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt)
+[CordaRPCOps.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt)
 
 The API provides both static (snapshot) and dynamic (snapshot with streaming updates) methods for a defined set of
 filter criteria:
@@ -255,7 +255,7 @@ val results = builder {
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 {{< note >}}
 Custom contract states that implement the `Queryable` interface may now extend the common schema types `FungiblePersistentState` or, `LinearPersistentState`.  Previously, all custom contracts extended the root `PersistentState` class and defined repeated mappings of `FungibleAsset` and `LinearState` attributes. See `SampleCashSchemaV2` and `DummyLinearStateSchemaV2` as examples.
@@ -299,7 +299,7 @@ Vault.Page<ContractState> results = vaultService.queryBy(Cash.State.class, crite
 
 ```
 
-[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
+[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
 
 {{< note >}}
 Queries by `Party` specify the `AbstractParty` which may be concrete or anonymous. Note, however, that if an anonymous party does not resolve to an X500 name via the `IdentityService`, no query results will ever be produced. For performance reasons, queries do not use `PublicKey` as search criteria.
@@ -427,7 +427,7 @@ val metadata = result.statesMetadata
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 #### Query for unconsumed states for some state references:
 
@@ -438,7 +438,7 @@ val results = vaultService.queryBy<DummyLinearContract.State>(criteria, Sort(set
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 #### Query for unconsumed states for several contract state types:
 
@@ -448,7 +448,7 @@ val results = vaultService.queryBy<ContractState>(criteria)
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 #### Query for unconsumed states for specified contract state constraint types and sorted in ascending alphabetical order:
 
@@ -460,7 +460,7 @@ val constraintResults = vaultService.queryBy<LinearState>(constraintTypeCriteria
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 #### Query for unconsumed states for specified contract state constraints (type and data):
 
@@ -471,7 +471,7 @@ val constraintResults = vaultService.queryBy<LinearState>(constraintCriteria)
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 #### Query for unconsumed states for a given notary:
 
@@ -481,7 +481,7 @@ val results = vaultService.queryBy<ContractState>(criteria)
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 #### Query for unconsumed states for a given set of participants (matches any state that contains at least one of the specified participants):
 
@@ -491,7 +491,7 @@ val results = vaultService.queryBy<ContractState>(criteria)
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 #### Query for unconsumed states for a given set of participants (exactly matches only states that contain all specified participants):
 
@@ -501,7 +501,7 @@ val strictResults = vaultService.queryBy<ContractState>(strictCriteria)
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 #### Query for unconsumed states recorded between two time intervals:
 
@@ -516,7 +516,7 @@ val results = vaultService.queryBy<ContractState>(criteria)
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 {{< note >}}
 This example illustrates usage of a `Between` `ColumnPredicate`.
@@ -531,7 +531,7 @@ val results = vaultService.queryBy<ContractState>(criteria, paging = pagingSpec)
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 {{< note >}}
 The result set metadata field *totalStatesAvailable* allows you to further paginate accordingly as
@@ -552,7 +552,7 @@ do {
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 #### Query for only relevant states in the vault:
 
@@ -562,7 +562,7 @@ do {
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 ### LinearState and DealState queries using `LinearStateQueryCriteria`:
 
@@ -575,7 +575,7 @@ val results = vaultService.queryBy<LinearState>(criteria)
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 #### Query for all linear states associated with a linear ID:
 
@@ -586,7 +586,7 @@ val results = vaultService.queryBy<LinearState>(linearStateCriteria and vaultCri
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 #### Query for unconsumed deal states with deal references:
 
@@ -596,7 +596,7 @@ val results = vaultService.queryBy<DealState>(criteria)
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 #### Query for unconsumed deal states with deal parties (any match):
 
@@ -606,7 +606,7 @@ val results = vaultService.queryBy<DealState>(criteria)
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 #### Query for unconsumed deal states with deal parties (exact match):
 
@@ -616,7 +616,7 @@ val strictResults = vaultService.queryBy<ContractState>(strictCriteria)
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 #### Query for only relevant linear states in the vault:
 
@@ -626,7 +626,7 @@ val strictResults = vaultService.queryBy<ContractState>(strictCriteria)
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 ### FungibleAsset and DealState queries using `FungibleAssetQueryCriteria`:
 
@@ -639,7 +639,7 @@ val results = vaultService.queryBy<FungibleAsset<*>>(criteria)
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 #### Query for fungible assets for a minimum quantity:
 
@@ -649,7 +649,7 @@ val results = vaultService.queryBy<Cash.State>(fungibleAssetCriteria)
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 {{< note >}}
 This example uses the builder DSL.
@@ -663,7 +663,7 @@ val results = vaultService.queryBy<FungibleAsset<*>>(criteria)
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 #### Query for only relevant fungible states in the vault:
 
@@ -673,7 +673,7 @@ val allCashStates = vaultService.queryBy<Cash.State>(allCashCriteria).states
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 ### Aggregate Function queries using `VaultCustomQueryCriteria`:
 
@@ -707,7 +707,7 @@ val results = vaultService.queryBy<FungibleAsset<*>>(sumCriteria
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 {{< note >}}
 `otherResults` will contain 5 items, one per calculated aggregate function.
@@ -735,7 +735,7 @@ val results = vaultService.queryBy<FungibleAsset<*>>(sumCriteria
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 {{< note >}}
 `otherResults` will contain 24 items, one result per calculated aggregate function per currency (the grouping attribute - currency in this case - is returned per aggregate result).
@@ -754,7 +754,7 @@ val results = vaultService.queryBy<FungibleAsset<*>>(VaultCustomQueryCriteria(su
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 {{< note >}}
 `otherResults` will contain 12 items sorted from largest summed cash amount to smallest, one result per calculated aggregate function per issuer party and currency (grouping attributes are returned per aggregate result).
@@ -770,7 +770,7 @@ Dynamic queries (also using `VaultQueryCriteria`) are an extension to the snapsh
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 #### Track unconsumed linear states:
 
@@ -779,7 +779,7 @@ val (snapshot, updates) = vaultService.trackBy<LinearState>()
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 {{< note >}}
 This will return both `DealState` and `LinearState` states.
@@ -792,7 +792,7 @@ val (snapshot, updates) = vaultService.trackBy<DealState>()
 
 ```
 
-[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
+[VaultQueryTests.kt](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/kotlin/net/corda/node/services/vault/VaultQueryTests.kt)
 
 {{< note >}}
 This will return only `DealState` states.
@@ -809,7 +809,7 @@ Vault.Page<LinearState> results = vaultService.queryBy(LinearState.class);
 
 ```
 
-[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
+[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
 
 #### Query for all consumed cash states:
 
@@ -819,7 +819,7 @@ Vault.Page<Cash.State> results = vaultService.queryBy(Cash.State.class, criteria
 
 ```
 
-[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
+[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
 
 #### Query for consumed deal states or linear IDs, specify a paging specification and sort by unique identifier:
 
@@ -844,7 +844,7 @@ Vault.Page<LinearState> results = vaultService.queryBy(LinearState.class, compos
 
 ```
 
-[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
+[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
 
 #### Query for all states using a pagination specification and iterate using the *totalStatesAvailable* field until no further pages available:
 
@@ -864,7 +864,7 @@ do {
 
 ```
 
-[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
+[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
 
 ### Aggregate Function queries using `VaultCustomQueryCriteria`:
 
@@ -896,7 +896,7 @@ Vault.Page<Cash.State> results = vaultService.queryBy(Cash.State.class, criteria
 
 ```
 
-[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
+[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
 
 #### Aggregations on cash grouped by currency for various functions:
 
@@ -915,7 +915,7 @@ Vault.Page<Cash.State> results = vaultService.queryBy(Cash.State.class, criteria
 
 ```
 
-[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
+[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
 
 #### Sum aggregation on cash grouped by issuer party and currency and sorted by sum:
 
@@ -928,7 +928,7 @@ Vault.Page<Cash.State> results = vaultService.queryBy(Cash.State.class, sumCrite
 
 ```
 
-[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
+[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
 
 #### Track unconsumed cash states:
 
@@ -944,7 +944,7 @@ Vault.Page<ContractState> snapshot = results.getSnapshot();
 
 ```
 
-[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
+[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
 
 #### Track unconsumed deal states or linear states (with snapshot including specification of paging and sorting by unique identifier):
 
@@ -969,7 +969,7 @@ Vault.Page<ContractState> snapshot = results.getSnapshot();
 
 ```
 
-[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.8/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
+[VaultQueryJavaTests.java](https://github.com/corda/corda/blob/release/os/4.10/node/src/test/java/net/corda/node/services/vault/VaultQueryJavaTests.java)
 
 
 ## Troubleshooting

--- a/content/en/platform/corda/4.10/community/apps/bankinabox/back-end-guide.md
+++ b/content/en/platform/corda/4.10/community/apps/bankinabox/back-end-guide.md
@@ -121,7 +121,7 @@ The method checks that the account has sufficient funds - in either the account 
 
 #### Custom serialization
 
-Corda uses the [Kryo serializer](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/serialization-index.md) to serialize objects on the call stack when suspending flows. There are known issues serializing JPA entity objects, particularly if they use one to many relationships or other complex structures. One approach to overcome this is to map entity objects to data classes, referred to as Data Transfer Objects (DTOs), for use within flows. Another approach is to implement custom serializers that generate the serialization for Kryo.
+Corda uses the [Kryo serializer]({{< relref "../../serialization-index.md" >}}) to serialize objects on the call stack when suspending flows. There are known issues serializing JPA entity objects, particularly if they use one to many relationships or other complex structures. One approach to overcome this is to map entity objects to data classes, referred to as Data Transfer Objects (DTOs), for use within flows. Another approach is to implement custom serializers that generate the serialization for Kryo.
 
 A custom serializer for a JPA entity can be specified with the `DefaultSerializer` annotation:
 
@@ -184,7 +184,7 @@ To create a new customer, use the `CreateCustomerFlow`. This flow also adds pers
 * `contactNumber`: Customer phone number.
 * `emailAddress`: Customer email address.
 * `postCode`: Post code of customer's address.
-* `attachments`: List of `SecureHash`, `String` pairs with references to the Corda attachments of additional customer documentation. For more information on the standard process for uploading attachments to Corda, see the documentation on [CorDapp Contract Attachments](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/cordapp-build-systems.md).
+* `attachments`: List of `SecureHash`, `String` pairs with references to the Corda attachments of additional customer documentation. For more information on the standard process for uploading attachments to Corda, see the documentation on [CorDapp Contract Attachments]({{< relref "../../cordapp-build-systems.md#cordapp-contract-attachments" >}}).
 
 This flows returns `UUID`, the customer ID.
 
@@ -324,11 +324,11 @@ subFlow(ApproveOverdraftFlow(accountId, amount))
 
 ## Loans
 
-The Bank in a Box application uses [Oracles](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/key-concepts-oracles.md) in various contexts, one of which is in the issuance of loans. A dummy Oracle is used to call external services based on a customer ID and sign off on the loan. The response is then embedded in the transaction that issues the loan. This mimics a real-life scenario where a bank calls a rating provider before giving a customer a loan.
+The Bank in a Box application uses [Oracles]({{< relref "../../key-concepts-oracles.md" >}}) in various contexts, one of which is in the issuance of loans. A dummy Oracle is used to call external services based on a customer ID and sign off on the loan. The response is then embedded in the transaction that issues the loan. This mimics a real-life scenario where a bank calls a rating provider before giving a customer a loan.
 
-Oracle signatures use [partial Merkle tree signing](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/key-concepts-tearoffs.md), which provides privacy for the transaction. In this way, the external party present in the loan issuance transaction can only see the contents of the transaction that they must confirm before signing the transaction.
+Oracle signatures use [partial Merkle tree signing]({{< relref "../../key-concepts-tearoffs.md#merkle-trees-on-corda" >}}), which provides privacy for the transaction. In this way, the external party present in the loan issuance transaction can only see the contents of the transaction that they must confirm before signing the transaction.
 
-When a loan is issued, money is transferred to the customer's current account. In the background, this transaction uses [Corda scheduled states](../../../enterprise/event-scheduling.html#how-to-implement-scheduled-events) to create a recurring payment for that loan, into the loan account.
+When a loan is issued, money is transferred to the customer's current account. In the background, this transaction uses [Corda scheduled states]({{< relref "../../../enterprise/event-scheduling.md#implementing-scheduled-events" >}}) to create a recurring payment for that loan, into the loan account.
 
 ### Business logic
 
@@ -741,7 +741,7 @@ The business logic behind Bank in a Box payments is explained below, addressing:
 
 #### Deduplicating payment logs
 
-In Corda, notaries prevent the double spending of contract states but this naturally excludes off-ledger systems. Instead, Corda provides a <a href="https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/api-flows.md">`FlowExternalOperation`</a> that is executed with a `deduplicationId`, allowing for custom handling of duplicate runs. Each recurring payment execution is logged and duplicate logs can be avoided by creating the payment log instance within a subclass of `FlowExternalOperation`. 
+In Corda, notaries prevent the double spending of contract states but this naturally excludes off-ledger systems. Instead, Corda provides a [FlowExternalOperation]({{< relref "../../api-flows.md" >}}) that is executed with a `deduplicationId`, allowing for custom handling of duplicate runs. Each recurring payment execution is logged and duplicate logs can be avoided by creating the payment log instance within a subclass of `FlowExternalOperation`. 
 
 The skeleton `CreateRecurringPaymentLogOperation` is as follows:
 

--- a/content/en/platform/corda/4.10/community/apps/bankinabox/back-end-guide.md
+++ b/content/en/platform/corda/4.10/community/apps/bankinabox/back-end-guide.md
@@ -121,7 +121,7 @@ The method checks that the account has sufficient funds - in either the account 
 
 #### Custom serialization
 
-Corda uses the [Kryo serializer](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/serialization-index.md) to serialize objects on the call stack when suspending flows. There are known issues serializing JPA entity objects, particularly if they use one to many relationships or other complex structures. One approach to overcome this is to map entity objects to data classes, referred to as Data Transfer Objects (DTOs), for use within flows. Another approach is to implement custom serializers that generate the serialization for Kryo.
+Corda uses the [Kryo serializer](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/serialization-index.md) to serialize objects on the call stack when suspending flows. There are known issues serializing JPA entity objects, particularly if they use one to many relationships or other complex structures. One approach to overcome this is to map entity objects to data classes, referred to as Data Transfer Objects (DTOs), for use within flows. Another approach is to implement custom serializers that generate the serialization for Kryo.
 
 A custom serializer for a JPA entity can be specified with the `DefaultSerializer` annotation:
 
@@ -184,7 +184,7 @@ To create a new customer, use the `CreateCustomerFlow`. This flow also adds pers
 * `contactNumber`: Customer phone number.
 * `emailAddress`: Customer email address.
 * `postCode`: Post code of customer's address.
-* `attachments`: List of `SecureHash`, `String` pairs with references to the Corda attachments of additional customer documentation. For more information on the standard process for uploading attachments to Corda, see the documentation on [CorDapp Contract Attachments](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/cordapp-build-systems.md).
+* `attachments`: List of `SecureHash`, `String` pairs with references to the Corda attachments of additional customer documentation. For more information on the standard process for uploading attachments to Corda, see the documentation on [CorDapp Contract Attachments](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/cordapp-build-systems.md).
 
 This flows returns `UUID`, the customer ID.
 
@@ -324,9 +324,9 @@ subFlow(ApproveOverdraftFlow(accountId, amount))
 
 ## Loans
 
-The Bank in a Box application uses [Oracles](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/key-concepts-oracles.md) in various contexts, one of which is in the issuance of loans. A dummy Oracle is used to call external services based on a customer ID and sign off on the loan. The response is then embedded in the transaction that issues the loan. This mimics a real-life scenario where a bank calls a rating provider before giving a customer a loan.
+The Bank in a Box application uses [Oracles](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/key-concepts-oracles.md) in various contexts, one of which is in the issuance of loans. A dummy Oracle is used to call external services based on a customer ID and sign off on the loan. The response is then embedded in the transaction that issues the loan. This mimics a real-life scenario where a bank calls a rating provider before giving a customer a loan.
 
-Oracle signatures use [partial Merkle tree signing](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/key-concepts-tearoffs.md), which provides privacy for the transaction. In this way, the external party present in the loan issuance transaction can only see the contents of the transaction that they must confirm before signing the transaction.
+Oracle signatures use [partial Merkle tree signing](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/key-concepts-tearoffs.md), which provides privacy for the transaction. In this way, the external party present in the loan issuance transaction can only see the contents of the transaction that they must confirm before signing the transaction.
 
 When a loan is issued, money is transferred to the customer's current account. In the background, this transaction uses [Corda scheduled states](../../../enterprise/event-scheduling.html#how-to-implement-scheduled-events) to create a recurring payment for that loan, into the loan account.
 
@@ -741,7 +741,7 @@ The business logic behind Bank in a Box payments is explained below, addressing:
 
 #### Deduplicating payment logs
 
-In Corda, notaries prevent the double spending of contract states but this naturally excludes off-ledger systems. Instead, Corda provides a <a href="https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/api-flows.md">`FlowExternalOperation`</a> that is executed with a `deduplicationId`, allowing for custom handling of duplicate runs. Each recurring payment execution is logged and duplicate logs can be avoided by creating the payment log instance within a subclass of `FlowExternalOperation`. 
+In Corda, notaries prevent the double spending of contract states but this naturally excludes off-ledger systems. Instead, Corda provides a <a href="https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/api-flows.md">`FlowExternalOperation`</a> that is executed with a `deduplicationId`, allowing for custom handling of duplicate runs. Each recurring payment execution is logged and duplicate logs can be avoided by creating the payment log instance within a subclass of `FlowExternalOperation`. 
 
 The skeleton `CreateRecurringPaymentLogOperation` is as follows:
 

--- a/content/en/platform/corda/4.10/community/apps/bankinabox/getting-started.md
+++ b/content/en/platform/corda/4.10/community/apps/bankinabox/getting-started.md
@@ -36,7 +36,7 @@ You will also need the following to work on Bank in a Box:
 
 Bank in a Box has the following computational requirements:
 
-* Memory: 6 Gibibytes
+* Memory: 6 Gigabytes
 * CPU: 2000m (2 full cores)
 
 ### Notes on Kubernetes cluster setup

--- a/content/en/platform/corda/4.10/community/apps/bankinabox/getting-started.md
+++ b/content/en/platform/corda/4.10/community/apps/bankinabox/getting-started.md
@@ -18,9 +18,9 @@ Follow this guide to set up Bank in a Box so you can start testing its features 
 
 ## Prerequisites
 
-Testing the Bank in a Box CorDapp or building your own banking CorDapp both require some Corda programming knowledge. If you are new to Corda, read about [Corda key concepts](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/key-concepts.md) and [CorDapps](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/cordapp-overview.md) to get up to speed.
+Testing the Bank in a Box CorDapp or building your own banking CorDapp both require some Corda programming knowledge. If you are new to Corda, read about [Corda key concepts]({{< relref "../../key-concepts.md" >}}) and [CorDapps]({{< relref "../../cordapp-overview.md" >}} ) to get up to speed.
 
-Follow the general instructions for [Getting set up]({{< relref "../../../../4.10/community/getting-set-up.md" >}}) to develop CorDapps once you are ready to get started with Bank in a Box.
+Follow the general instructions for [Getting set up]({{< relref "../../getting-set-up.md" >}}) to develop CorDapps once you are ready to get started with Bank in a Box.
 
 You will also need the following to work on Bank in a Box:
 

--- a/content/en/platform/corda/4.10/community/apps/bankinabox/getting-started.md
+++ b/content/en/platform/corda/4.10/community/apps/bankinabox/getting-started.md
@@ -18,7 +18,7 @@ Follow this guide to set up Bank in a Box so you can start testing its features 
 
 ## Prerequisites
 
-Testing the Bank in a Box CorDapp or building your own banking CorDapp both require some Corda programming knowledge. If you are new to Corda, read about [Corda key concepts](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/key-concepts.md) and [CorDapps](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/cordapp-overview.md) to get up to speed.
+Testing the Bank in a Box CorDapp or building your own banking CorDapp both require some Corda programming knowledge. If you are new to Corda, read about [Corda key concepts](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/key-concepts.md) and [CorDapps](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/cordapp-overview.md) to get up to speed.
 
 Follow the general instructions for [Getting set up]({{< relref "../../../../4.10/community/getting-set-up.md" >}}) to develop CorDapps once you are ready to get started with Bank in a Box.
 

--- a/content/en/platform/corda/4.10/community/blob-inspector.md
+++ b/content/en/platform/corda/4.10/community/blob-inspector.md
@@ -21,10 +21,10 @@ title: Blob Inspector
 The Corda blob inspector tool gives you a human-readable view of content stored in a [custom binary serialization format](serialization.md).
 The blob inspector shows you the output of binary blob files (or URL end-points) in YAML or JSON using `JacksonSupport` (see [JSON](json.md) for more on Jackson serialization).
 
-The tool is distributed as a `.jar.` file - `corda-tools-blob-inspector-4.8.jar`. To run it, pass in the file or URL as the first parameter:
+The tool is distributed as a `.jar.` file - `corda-tools-blob-inspector-4.10.jar`. To run it, pass in the file or URL as the first parameter:
 
 ```kotlin
-java -jar corda-tools-blob-inspector-4.8.jar <file or URL>
+java -jar corda-tools-blob-inspector-4.10.jar <file or URL>
 ```
 
 

--- a/content/en/platform/corda/4.10/community/building-against-non-release.md
+++ b/content/en/platform/corda/4.10/community/building-against-non-release.md
@@ -63,4 +63,4 @@ time may differ. If you are using an unstable release and need help debugging an
 * Make a note of the `corda_release_version` in the root `build.gradle` file of the Corda repository.
 * In your CorDapp’s root `build.gradle` file:
   * Update `ext.corda_release_version` to the `corda_release_version` noted down earlier.
-  * Update `corda_gradle_plugins_version` to the `gradlePluginsVersion` noted down earlier - for Corda Enterprise Edition 4.8 this must be `ext.corda_gradle_plugins_version = '5.0.12'`.
+  * Update `corda_gradle_plugins_version` to the `gradlePluginsVersion` noted down earlier - for Corda Enterprise Edition 4.10 this must be `ext.corda_gradle_plugins_version = '5.0.12'`.

--- a/content/en/platform/corda/4.10/community/business-network-membership.md
+++ b/content/en/platform/corda/4.10/community/business-network-membership.md
@@ -56,7 +56,7 @@ In a Business Network, you can assign different roles to members of the network.
 
 ## Installation
 
-This is an extension for Corda 4.8. If you have this version of Corda, you can access the required JAR files here:
+This is an extension for Corda 4.10. If you have this version of Corda, you can access the required JAR files here:
 
 * [BNE contracts](https://software.r3.com/artifactory/webapp/#/artifacts/browse/tree/General/corda-releases/net/corda/bn/business-networks-contracts/1.1/business-networks-contracts-1.1.jar).
 * [BNE workflows](https://software.r3.com/artifactory/webapp/#/artifacts/browse/tree/General/corda-releases/net/corda/bn/business-networks-workflows/1.1/business-networks-workflows-1.1.jar).

--- a/content/en/platform/corda/4.10/community/cli-application-shell-extensions.md
+++ b/content/en/platform/corda/4.10/community/cli-application-shell-extensions.md
@@ -51,7 +51,7 @@ You will now be able to run the command line application from anywhere by runnin
 For example, for the Corda node, install the shell extensions using
 
 ```shell
-java -jar corda-4.8.jar install-shell-extensions
+java -jar corda-4.10.jar install-shell-extensions
 ```
 
 And then run the node by running:
@@ -86,9 +86,9 @@ restart the shell or see [above](#installing-shell-extensions) for instructions 
 
 |Description|Alias|JAR Name|
 |---------------------------------------------------------|------------------------------|----------------------------------------------------------|
-|[Corda node](running-a-node.html#starting-an-individual-corda-node)|`corda --<option>`|`corda-4.8.jar`|
-|[Network bootstrapper]({{% ref "network-bootstrapper.md" %}})|`bootstrapper --<option>`|`corda-tools-network-bootstrapper-4.8.jar`|
-|[Standalone shell](shell.html#standalone-shell)|`corda-shell --<option>`|`corda-tools-shell-cli-4.8.jar`|
-|[Blob inspector]({{% ref "blob-inspector.md" %}})|`blob-inspector --<option>`|`corda-tools-blob-inspector-4.8.jar`|
+|[Corda node](running-a-node.html#starting-an-individual-corda-node)|`corda --<option>`|`corda-4.10.jar`|
+|[Network bootstrapper]({{% ref "network-bootstrapper.md" %}})|`bootstrapper --<option>`|`corda-tools-network-bootstrapper-4.10.jar`|
+|[Standalone shell](shell.html#standalone-shell)|`corda-shell --<option>`|`corda-tools-shell-cli-4.10.jar`|
+|[Blob inspector]({{% ref "blob-inspector.md" %}})|`blob-inspector --<option>`|`corda-tools-blob-inspector-4.10.jar`|
 
 {{< /table >}}

--- a/content/en/platform/corda/4.10/community/clientrpc.md
+++ b/content/en/platform/corda/4.10/community/clientrpc.md
@@ -26,25 +26,25 @@ Corda supports two types of RPC client:
 * **Multi RPC Client**, which is used if you want to interact with your node via the `CordaRPCOps` remote interface, as an alternative to the Corda RPC Client. Compared to the Corda RPC Client, the Multi RPC Client is more flexible with handling connection speed variations when started in HA mode, through the use of the [RPCConnectionListener interface](#adding-rpc-connection-listeners).
 
 {{< warning >}}
-The built-in Corda test webserver is deprecated and unsuitable for production use. If you want to interact with your node via HTTP, you will need to stand up your own webserver that connects to your node using the [CordaRPCClient](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/rpc/CordaRPCClient.html) class. You can find an example of how to do this using the popular Spring Boot server [here](https://github.com/corda/spring-webserver).
+The built-in Corda test webserver is deprecated and unsuitable for production use. If you want to interact with your node via HTTP, you will need to stand up your own webserver that connects to your node using the [CordaRPCClient](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/rpc/CordaRPCClient.html) class. You can find an example of how to do this using the popular Spring Boot server [here](https://github.com/corda/spring-webserver).
 {{< /warning >}}
 
 
 ## Building the Corda RPC Client
 
-To interact with your node via the `CordaRPCOps` remote interface, you need to build a client that uses the [CordaRPCClient](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/rpc/CordaRPCClient.html) class. The `CordaRPCClient` class enables you to connect to your node via a message queue protocol and provides a simple RPC interface (the `CordaRPCOps` remote interface) for interacting with the node. You make calls on a JVM object as normal, and the marshalling back-and-forth is handled for you.
+To interact with your node via the `CordaRPCOps` remote interface, you need to build a client that uses the [CordaRPCClient](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/rpc/CordaRPCClient.html) class. The `CordaRPCClient` class enables you to connect to your node via a message queue protocol and provides a simple RPC interface (the `CordaRPCOps` remote interface) for interacting with the node. You make calls on a JVM object as normal, and the marshalling back-and-forth is handled for you.
 
 ### Pre-requisites
 
-To use the [CordaRPCClient](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/rpc/CordaRPCClient.html) class, you must add `net.corda:corda-rpc:$corda_release_version` as a `cordaCompile` dependency in your client’s `build.gradle` file.
+To use the [CordaRPCClient](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/rpc/CordaRPCClient.html) class, you must add `net.corda:corda-rpc:$corda_release_version` as a `cordaCompile` dependency in your client’s `build.gradle` file.
 
 ### Connecting to a node with `CordaRPCClient`
 
-The [CordaRPCClient](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/rpc/CordaRPCClient.html) class has a `start` method that takes the node’s RPC address and returns a [CordaRPCConnection](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/rpc/CordaRPCConnection.html).
+The [CordaRPCClient](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/rpc/CordaRPCClient.html) class has a `start` method that takes the node’s RPC address and returns a [CordaRPCConnection](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/rpc/CordaRPCConnection.html).
 
-The [CordaRPCConnection](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/rpc/CordaRPCConnection.html) class has a `proxy` method that takes an RPC username and password and returns a [CordaRPCOps](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/core/messaging/CordaRPCOps.html) object that you can use to interact with the node.
+The [CordaRPCConnection](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/rpc/CordaRPCConnection.html) class has a `proxy` method that takes an RPC username and password and returns a [CordaRPCOps](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/core/messaging/CordaRPCOps.html) object that you can use to interact with the node.
 
-Here is an example of using [CordaRPCClient](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/rpc/CordaRPCClient.html) to connect to a node and log the current time on its internal clock:
+Here is an example of using [CordaRPCClient](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/rpc/CordaRPCClient.html) to connect to a node and log the current time on its internal clock:
 
 {{< tabs name="tabs-1" >}}
 {{% tab name="kotlin" %}}
@@ -114,7 +114,7 @@ class ClientRpcExample {
 {{< /tabs >}}
 
 {{< warning >}}
-The returned [CordaRPCConnection](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/rpc/CordaRPCConnection.html) is somewhat expensive to create and consumes a small amount of server-side resources. When you’re done with it, call `close` on it. Alternatively, you would typically employ the `use` method on [CordaRPCClient](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/rpc/CordaRPCClient.html), which cleans up automatically after the passed in lambda finishes. Do not create a new proxy for every call you make: reuse an existing one.
+The returned [CordaRPCConnection](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/rpc/CordaRPCConnection.html) is somewhat expensive to create and consumes a small amount of server-side resources. When you’re done with it, call `close` on it. Alternatively, you would typically employ the `use` method on [CordaRPCClient](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/rpc/CordaRPCClient.html), which cleans up automatically after the passed in lambda finishes. Do not create a new proxy for every call you make: reuse an existing one.
 {{< /warning >}}
 
 For further information on using the RPC API, see [Working with the CordaRPCClient API]({{< relref "../enterprise/get-started/tutorials/supplementary-tutorials/tutorial-clientrpc-api.md" >}}). 
@@ -365,11 +365,11 @@ This approach provides at-least-once guarantees. It cannot provide exactly-once 
 
 The Multi RPC Client in Corda Community Edition can be used as an extension of the [net.corda.core.messaging.CordaRPCOps](https://docs.r3.com/en/api-ref/corda/4.10/community/javadoc/index.html) remote interface.
 
-To interact with your node via this interface, you need to build a client that uses the [MultiRPCClient](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) class.
+To interact with your node via this interface, you need to build a client that uses the [MultiRPCClient](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) class.
 
 ### Pre-requisites
 
-To use the functionality of the [MultiRPCClient](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) class from a custom JVM application, you must include the following dependency:
+To use the functionality of the [MultiRPCClient](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) class from a custom JVM application, you must include the following dependency:
 
 ```groovy
 dependencies {
@@ -380,7 +380,7 @@ dependencies {
 
 ### Connecting to a node with `MultiRPCClient`
 
-The code snippet below demonstrates how to use the [MultiRPCClient](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) class to build a Multi RPC Client and define the following:
+The code snippet below demonstrates how to use the [MultiRPCClient](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) class to build a Multi RPC Client and define the following:
 
 * Endpoint address.
 * Interface class to be used for communication (in this example, `CordaRPCOps::class.java`, which is used to communicate with the `net.corda.core.messaging.CordaRPCOps` interface).
@@ -434,24 +434,24 @@ As some internal resources are allocated to `MultiRPCClient`, it is recommended 
 
 You can pass in multiple endpoint addresses when constructing `MultiRPCClient`. If you do so, `MultiRPCClient` will operate in fail-over mode and if one of the endpoints becomes unreachable, it will automatically retry the connection using a round-robin policy.
 
-For more information, see the API documentation for [MultiRPCClient](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html).
+For more information, see the API documentation for [MultiRPCClient](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html).
 
 ### Adding RPC connection listeners
 
 If the reconnection cycle has started, the previously supplied `RPCConnection` may become interrupted and `proxy` will throw an `RPCException` every time the remote method is called.
 
-To be notified when the connection has been re-established or, indeed, to receive notifications throughout the lifecycle of every connection, you can add one or more [RPCConnectionListeners](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/rpc/ext/RPCConnectionListener.html) to `MultiRPCClient`.
-For more information, see the API documentation reference for the [RPCConnectionListener](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/rpc/ext/RPCConnectionListener.html)) interface.
+To be notified when the connection has been re-established or, indeed, to receive notifications throughout the lifecycle of every connection, you can add one or more [RPCConnectionListeners](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/rpc/ext/RPCConnectionListener.html) to `MultiRPCClient`.
+For more information, see the API documentation reference for the [RPCConnectionListener](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/rpc/ext/RPCConnectionListener.html)) interface.
 
 {{< note >}}
-Using the [RPCConnectionListener](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/rpc/ext/RPCConnectionListener.html) interface with the Multi RPC Client enables it to better handle connection speed variations when it is started in HA mode.
+Using the [RPCConnectionListener](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/rpc/ext/RPCConnectionListener.html) interface with the Multi RPC Client enables it to better handle connection speed variations when it is started in HA mode.
 {{< /note >}}
 
 ### Specifying RPC connection parameters
 
-Many constructors are available for `MultiRPCClient`. This enables you to specify a variety of other configuration parameters relating to the RPC connection. The parameters for `MultiRPCClient` are largely similar to the parameters for the [CordaRPCClient](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/rpc/CordaRPCClient.html).
+Many constructors are available for `MultiRPCClient`. This enables you to specify a variety of other configuration parameters relating to the RPC connection. The parameters for `MultiRPCClient` are largely similar to the parameters for the [CordaRPCClient](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/rpc/CordaRPCClient.html).
 
-For more information, see [MultiRPCClient](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) in the API documentation.
+For more information, see [MultiRPCClient](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/rpc/ext/MultiRPCClient.html) in the API documentation.
 
 ## Managing RPC security
 
@@ -640,7 +640,7 @@ The node admin must then create a node-specific RPC certificate and key, by runn
 
 The generated RPC TLS trust root certificate is exported to a `certificates/export/rpcssltruststore.jks` file, which should be distributed to the authorised RPC clients.
 
-The connecting `CordaRPCClient` code must then use one of the constructors with a parameter of type `ClientRpcSslOptions` ([JavaDoc](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/rpc/CordaRPCClient.html)) and set this constructor
+The connecting `CordaRPCClient` code must then use one of the constructors with a parameter of type `ClientRpcSslOptions` ([JavaDoc](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/rpc/CordaRPCClient.html)) and set this constructor
 argument with the appropriate path for the `rpcssltruststore.jks` file. The client connection will then use this to validate the RPC server handshake.
 
 Note that RPC TLS does not use mutual authentication, and delegates fine-grained user authentication and authorisation to the RPC security features detailed under [Managing RPC security](#managing-rpc-security).

--- a/content/en/platform/corda/4.10/community/codestyle.md
+++ b/content/en/platform/corda/4.10/community/codestyle.md
@@ -22,7 +22,7 @@ recommendations when submitting patches for review. Please take the time to read
 time during code review.
 
 What follows are mostly *recommendations* and not *rules*. They are in places intentionally vague, so use your good judgement
-when interpreting them. The rules that are currently being enforced via the Detekt PR gateway can be found [here](https://github.com/corda/corda/blob/release/os/4.3/detekt-config.yml).
+when interpreting them. The rules that are currently being enforced via the Detekt PR gateway can be found [here](https://github.com/corda/corda/blob/release/os/4.10/detekt-config.yml).
 
 
 ## 1. General style

--- a/content/en/platform/corda/4.10/community/contributing-philosophy.md
+++ b/content/en/platform/corda/4.10/community/contributing-philosophy.md
@@ -66,7 +66,7 @@ You can contact our community maintainers in the `#contributing` channel on the 
 ## Existing Contributors
 
 Over two hundred individuals have contributed to the development of Corda. You can find a full list of contributors in the
-[CONTRIBUTORS.md list](https://github.com/corda/corda/blob/release/os/4.8/CONTRIBUTORS.md).
+[CONTRIBUTORS.md list](https://github.com/corda/corda/blob/release/os/4.10/CONTRIBUTORS.md).
 
 
 ## Transparency and Conflict Policy

--- a/content/en/platform/corda/4.10/community/contributing.md
+++ b/content/en/platform/corda/4.10/community/contributing.md
@@ -66,8 +66,8 @@ Github branch is always the current development branch of Corda. Development wor
 unless the work is needed in a specific version of Corda. In that case, development work should target the oldest version
 of Corda for which the work would be appropriate. For instance, if a pull request would be applicable to Corda 4.6 and
 Corda 4.8, it would be appropriate to open a pull request for *release/os/4.6*. That work would then be merged forward
-from *release/os/4.6* to *release/os/4.8*. If the work is only applicable to Corda 4.8, a pull request need only be
-opened against release/os/4.8.
+from *release/os/4.6* to *release/os/4.10*. If the work is only applicable to Corda 4.10, a pull request need only be
+opened against release/os/4.10.
 
 
 ### Things to check
@@ -133,7 +133,7 @@ the [Community Maintainers](contributing-philosophy.html#community-maintainers) 
     * Leave comments requesting changes via the GitHub PR interface.
 
 3. Make the changes by pushing directly to your existing PR branch. The PR updates automatically.
-4. *Optional:* Open an additional PR to add yourself to the [contributors list](https://github.com/corda/corda/blob/release/os/4.4/CONTRIBUTORS.md). The format is generally `firstname surname (company)`. You can omit the company name.
+4. *Optional:* Open an additional PR to add yourself to the [contributors list](https://github.com/corda/corda/blob/release/os/4.10/CONTRIBUTORS.md). The format is generally `firstname surname (company)`. You can omit the company name.
 
 ## Large contributions
 

--- a/content/en/platform/corda/4.10/community/contributing.md
+++ b/content/en/platform/corda/4.10/community/contributing.md
@@ -65,7 +65,7 @@ Note that *release* is always part of the name of the branch, even for unrelease
 Github branch is always the current development branch of Corda. Development work should target the default branch
 unless the work is needed in a specific version of Corda. In that case, development work should target the oldest version
 of Corda for which the work would be appropriate. For instance, if a pull request would be applicable to Corda 4.6 and
-Corda 4.8, it would be appropriate to open a pull request for *release/os/4.6*. That work would then be merged forward
+Corda 4.10, it would be appropriate to open a pull request for *release/os/4.6*. That work would then be merged forward
 from *release/os/4.6* to *release/os/4.10*. If the work is only applicable to Corda 4.10, a pull request need only be
 opened against release/os/4.10.
 

--- a/content/en/platform/corda/4.10/community/corda-configuration-file.md
+++ b/content/en/platform/corda/4.10/community/corda-configuration-file.md
@@ -200,7 +200,7 @@ verifierType = InMemory
 
 ```
 
-[reference.conf](https://github.com/corda/corda/blob/release/os/4.8/node/src/main/resources/corda-reference.conf)
+[reference.conf](https://github.com/corda/corda/blob/release/os/4.10/node/src/main/resources/corda-reference.conf)
 
 ## Configuration examples
 

--- a/content/en/platform/corda/4.10/community/cordapp-build-systems.md
+++ b/content/en/platform/corda/4.10/community/cordapp-build-systems.md
@@ -78,8 +78,8 @@ Current versions:
 ```groovy
 ext.corda_release_distribution = 'com.r3.corda'
 ext.corda_core_release_distribution = 'net.corda'
-ext.corda_release_version = '4.8'
-ext.corda_core_release_version = '4.8'
+ext.corda_release_version = '4.10'
+ext.corda_core_release_version = '4.10'
 ext.corda_gradle_plugins_version = '5.0.12'
 ext.quasar_version = '0.7.15_r3'
 ext.quasar_classifier=''
@@ -593,7 +593,7 @@ to use native features of a particular database). The finance CorDapp provides a
 CorDapp Contract JARs must be installed on a node by a trusted uploader, either by:
 
 * Installing manually as per [Installing the CorDapp JAR](#install-the-cordapp) and re-starting the node.
-* Uploading the attachment JAR to the node via RPC, either programmatically (see [Connecting to a node via RPC](../../../../../../en/platform/corda/4.8/enterprise/node/operating/clientrpc.html#connecting-to-a-node-with-cordarpcclient))
+* Uploading the attachment JAR to the node via RPC, either programmatically (see [Connecting to a node via RPC]({{< relref "../enterprise/node/operating/clientrpc.md#connecting-to-a-node-with-cordarpcclient" >}}))
   or via the shell using the command: `>>> run uploadAttachment jar: path/to/the/file.jar`.
 
 Contract attachments received over the p2p network are **untrusted** and throw a *UntrustedAttachmentsException* exception if they are processed by a listening flow that cannot resolve the attachment with its local attachment storage. The flow will be suspended and sent to the node's `node-flow-hospital` for recovery and retry.

--- a/content/en/platform/corda/4.10/community/cordapp-constraint-migration.md
+++ b/content/en/platform/corda/4.10/community/cordapp-constraint-migration.md
@@ -140,12 +140,12 @@ by different parties and it will be expressed as a `CompositeKey` in the `Signat
 to all nodes in that CZ). The CZ network operator should check that the JAR is signed and not allow any more versions of it to be whitelisted in the future.
 From now on the development organisation that signed the JAR is responsible for signing new versions.The process of CZ network CorDapp whitelisting depends on how the Corda network is configured:
 
-* If using a hosted CZ network (such as [The Corda Network](https://docs.corda.net/head/corda-network/index.html) or
-[UAT Environment](https://docs.corda.net/head/corda-network/uat.html) ) running an Identity Operator (formerly known as Doorman) and
+* If using a hosted CZ network (such as [The Corda Network]({{< relref "corda-network/corda-network-foundation.md" >}}) or
+[UAT Environment]({{< relref "corda-network/uat.md" >}})) running an Identity Operator (formerly known as Doorman) and
 Network Map Service, you should manually send the hashes of the two JARs to the CZ network operator and request these be added using
 their network parameter update process.
 * If using a local network created using the Network Bootstrapper tool, please follow the instructions in
-[Updating the contract whitelist for bootstrapped networks](network-bootstrapper.md) to can add both CorDapp Contract JAR hashes.
+[Updating the contract whitelist for bootstrapped networks]({{< relref "network-bootstrapper.md" >}}) to can add both CorDapp Contract JAR hashes.
 * Any flow that builds transactions using this CorDapp will automatically transition states to use the `SignatureAttachmentConstraint` if
 no other constraint is specified and the CorDapp continues to be whitelisted. Therefore, there are two ways to alter the existing code.
   * Do not specify a constraint

--- a/content/en/platform/corda/4.10/community/cordapp-upgradeability.md
+++ b/content/en/platform/corda/4.10/community/cordapp-upgradeability.md
@@ -34,7 +34,7 @@ receiver flows to use the new APIs and thus opting in to platform version 4. See
 * All constraint types (hash, CZ whitelisted, signature) are consumable within the same transaction if there is an associated contract attachment that satisfies all of them.
 * CorDapp Contract states generated on ledger using hash constraints are not directly migratable to signature constraints in this release.
 Your compatibility zone operator may whitelist a JAR previously used to issue hash constrained states, and then you can follow the manual
-process described in the paragraph below to migrate these to signature constraints. See [CorDapp constraints migration]({{M relref "cordapp-constraint-migration.md" >}}) for more information.
+process described in the paragraph below to migrate these to signature constraints. See [CorDapp constraints migration]({{< relref "cordapp-constraint-migration.md" >}}) for more information.
 * CorDapp Contract states generated on ledger using CZ whitelisted constraints are migratable to signature constraints using a manual process
 that requires programmatic code changes. See [CZ whitelisted constraints migration]({{< relref "cordapp-constraint-migration.md" >}}) for more information.
 * Explicit Contract Upgrades are only supported for hash and CZ whitelisted constraint types. See [Performing explicit contract and state upgrades]({{< relref "upgrading-cordapps.md" >}}) for more information.

--- a/content/en/platform/corda/4.10/community/cordapp-upgradeability.md
+++ b/content/en/platform/corda/4.10/community/cordapp-upgradeability.md
@@ -30,18 +30,18 @@ The following guarantees are made for CorDapps running on Corda 4.0
 * Compliant CorDapps compiled with previous versions of Corda (from 3.0) will execute without change on Corda 4.0{{< note >}}
 by “compliant”, we mean CorDapps that do not utilise Corda internal, non-stable or other non-committed public Corda APIs.{{< /note >}}
 Recommendation: security hardening changes in flow processing, specifically the `FinalityFlow`, recommend upgrading existing CorDapp
-receiver flows to use the new APIs and thus opting in to platform version 4. See [Step 5. Security: Upgrade your use of FinalityFlow](app-upgrade-notes.md) for more information.
+receiver flows to use the new APIs and thus opting in to platform version 4. See [Step 5. Security: Upgrade your use of FinalityFlow]({{< relref "app-upgrade-notes.md#5-improve-the-security-of-your-cordapp-by-upgrading-how-you-use-finalityflow" >}}) for more information.
 * All constraint types (hash, CZ whitelisted, signature) are consumable within the same transaction if there is an associated contract attachment that satisfies all of them.
 * CorDapp Contract states generated on ledger using hash constraints are not directly migratable to signature constraints in this release.
 Your compatibility zone operator may whitelist a JAR previously used to issue hash constrained states, and then you can follow the manual
-process described in the paragraph below to migrate these to signature constraints. See [CorDapp constraints migration](cordapp-constraint-migration.md) for more information.
+process described in the paragraph below to migrate these to signature constraints. See [CorDapp constraints migration]({{M relref "cordapp-constraint-migration.md" >}}) for more information.
 * CorDapp Contract states generated on ledger using CZ whitelisted constraints are migratable to signature constraints using a manual process
-that requires programmatic code changes. See [CZ whitelisted constraints migration](cordapp-constraint-migration.md) for more information.
-* Explicit Contract Upgrades are only supported for hash and CZ whitelisted constraint types. See [Performing explicit contract and state upgrades](upgrading-cordapps.md) for more information.
+that requires programmatic code changes. See [CZ whitelisted constraints migration]({{< relref "cordapp-constraint-migration.md" >}}) for more information.
+* Explicit Contract Upgrades are only supported for hash and CZ whitelisted constraint types. See [Performing explicit contract and state upgrades]({{< relref "upgrading-cordapps.md" >}}) for more information.
 * CorDapp contract attachments are not trusted from remote peers over the p2p network for the purpose of transaction verification.
 A node operator must locally install *all* versions of a Contract attachment to be able to resolve a chain of contract states from its original version.
 The RPC `uploadAttachment` mechanism can be used to achieve this (as well as conventional loading of a CorDapp by installing it in the nodes /cordapp directory).
-See [Installing the CorDapp JAR](cordapp-build-systems.md) and [CorDapp Contract Attachments](cordapp-build-systems.md) for more information.
+See [Installing the CorDapp JAR]({{< relref "cordapp-build-systems.md" >}}) and [CorDapp Contract Attachments]({{< relref "cordapp-build-systems.md" >}}) for more information.
 * CorDapp contract attachment classloader isolation has some important side-effects and edge cases to consider:
 * Contract attachments should include all 3rd party library dependencies in the same packaged JAR - we call this a “Fat JAR”,
 meaning that all dependencies are resolvable by the classloader by only loading a single JAR.
@@ -66,9 +66,9 @@ The following additional capabilities are under consideration for delivery in fo
 
 
 * CorDapp Contract states generated on ledger using hash constraints will be automatically migrated to signature constraints when building new transactions
-where the latest installed contract Jar is signed as per [CorDapp Jar signing](cordapp-build-systems.md).
+where the latest installed contract Jar is signed as per [CorDapp Jar signing]({{< relref "cordapp-build-systems.md" >}}).
 * CorDapp Contract states generated on ledger using CZ whitelisted constraints will be automatically migrated to signature constraints when building new transactions
-where the latest installed contract Jar is signed as per [CorDapp Jar signing](cordapp-build-systems.md).
+where the latest installed contract Jar is signed as per [CorDapp Jar signing]({{< relref "cordapp-build-systems.md" >}}).
 * Explicit Contract Upgrades will be supported for all constraint types: hash, CZ whitelisted and signature.
 In practice, it should only be necessary to upgrade from hash or CZ whitelisted to new signature constrained contract types.
 signature constrained Contracts are upgradeable seamlessly (through built in serialization and code signing controls) without requiring explicit upgrades.

--- a/content/en/platform/corda/4.10/community/deploying-a-node.md
+++ b/content/en/platform/corda/4.10/community/deploying-a-node.md
@@ -49,8 +49,8 @@ handling, and ensures the Corda service is run at boot.
    mkdir /opt/corda; chown corda:corda /opt/corda
    ```
 
-4. Download the [Corda jar](https://software.r3.com:443/artifactory/corda-releases/net/corda/corda/4.8)
-(under `/4.8/corda-4.8.jar`) and place it in `/opt/corda`.
+4. Download the [Corda jar](https://software.r3.com:443/artifactory/corda-releases/net/corda/corda/4.10)
+(under `/4.10/corda-4.10.jar`) and place it in `/opt/corda`.
 5. Create a directory called `cordapps` in `/opt/corda` and save your CorDapp jar file to it. Alternatively, download one of
 our [sample CorDapps](https://www.corda.net/samples/) to the `cordapps` directory.
 6. Save the following as `/opt/corda/node.conf`; see [Node configuration]({{< relref "corda-configuration-file.md" >}}) for a description of these options:

--- a/content/en/platform/corda/4.10/community/deterministic-modules.md
+++ b/content/en/platform/corda/4.10/community/deterministic-modules.md
@@ -105,7 +105,7 @@ deleted functions and properties are still present.
 
 ```
 
-[build.gradle](https://github.com/corda/corda/blob/release/os/4.8/core-deterministic/build.gradle)
+[build.gradle](https://github.com/corda/corda/blob/release/os/4.10/core-deterministic/build.gradle)
 
 This step will fail if ProGuard spots any Java API references that still cannot be satisfied by the deterministic
 `rt.jar`, and hence it will break the build.
@@ -233,7 +233,7 @@ Classes that *must* be included in the deterministic JAR should be annotated as 
 annotation class KeepForDJVM
 ```
 
-[KeepForDJVM.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/KeepForDJVM.kt)
+[KeepForDJVM.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/KeepForDJVM.kt)
 
 
 To preserve any Kotlin functions, properties or type aliases that have been declared outside of a `class`,
@@ -267,7 +267,7 @@ Elements that *must* be deleted from classes in the deterministic JAR should be 
 annotation class DeleteForDJVM
 ```
 
-[DeleteForDJVM.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/DeleteForDJVM.kt)
+[DeleteForDJVM.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/DeleteForDJVM.kt)
 
 
 You must also ensure that a deterministic class’s primary constructor does not reference any classes that are
@@ -331,7 +331,7 @@ annotation class StubOutForDJVM
 
 ```
 
-[StubOutForDJVM.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/StubOutForDJVM.kt)
+[StubOutForDJVM.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/StubOutForDJVM.kt)
 
 
 This annotation instructs `JarFilter` to replace the function’s body with either an empty body (for functions

--- a/content/en/platform/corda/4.10/community/financial-model.md
+++ b/content/en/platform/corda/4.10/community/financial-model.md
@@ -26,7 +26,7 @@ These provide a common language for states and contracts.
 
 ## Amount
 
-The [Amount](https://api.corda.net/api/corda-os/4.8/html/api/kotlin/corda/net.corda.core.contracts/-amount/index.html) class is used to represent an amount of
+The [Amount](https://api.corda.net/api/corda-os/4.10/html/api/kotlin/corda/net.corda.core.contracts/-amount/index.html) class is used to represent an amount of
 some fungible asset. It is a generic class which wraps around a type used to define the underlying product, called
 the *token*. For instance it can be the standard JDK type `Currency`, or an `Issued` instance, or this can be
 a more complex type such as an obligation contract issuance definition (which in turn contains a token definition

--- a/content/en/platform/corda/4.10/community/generating-a-node-cordform.md
+++ b/content/en/platform/corda/4.10/community/generating-a-node-cordform.md
@@ -231,7 +231,7 @@ running the bootstrapper.
 
 ## Package namespace ownership
 
-To configure [package namespace ownership](../../4.8/enterprise/node/deploy/env-dev.html#package-namespace-ownership), use the optional `networkParameterOverrides` and `packageOwnership` blocks, in a similar way to how the configuration file is used by the [Network Bootstrapper](network-bootstrapper.md) tool. For example:
+To configure [package namespace ownership]({{< relref "../enterprise/node/deploy/env-dev.md#package-namespace-ownership" >}}), use the optional `networkParameterOverrides` and `packageOwnership` blocks, in a similar way to how the configuration file is used by the [Network Bootstrapper](network-bootstrapper.md) tool. For example:
 
 ```groovy
 task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
@@ -308,7 +308,7 @@ The snippet below configures contracts classes from the Finance CorDapp to be ve
 
 ## Optional migration step
 
-If you are migrating your database schema from an older Corda version to Corda 4.8, you must add the following parameter to the node section in the `build.gradle` and set it to `true`:
+If you are migrating your database schema from an older Corda version to Corda 4.10, you must add the following parameter to the node section in the `build.gradle` and set it to `true`:
 
   ```
           runSchemaMigration = true

--- a/content/en/platform/corda/4.10/community/get-started/tutorials/supplementary-tutorials/contract-upgrade.md
+++ b/content/en/platform/corda/4.10/community/get-started/tutorials/supplementary-tutorials/contract-upgrade.md
@@ -71,7 +71,7 @@ class Authorise(
 
 ```
 
-[ContractUpgradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt)
+[ContractUpgradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt)
 
 ```kotlin
 @StartableByRPC
@@ -81,7 +81,7 @@ class Deauthorise(val stateRef: StateRef) : FlowLogic<Void?>() {
 
 ```
 
-[ContractUpgradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt)
+[ContractUpgradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt)
 
 
 ## Proposing an upgrade
@@ -160,7 +160,7 @@ class DummyContractV2 : UpgradedContractWithLegacyConstraint<DummyContract.State
 
 ```
 
-[DummyContractV2.kt](https://github.com/corda/corda/blob/release/os/4.8/testing/core-test-utils/src/main/kotlin/net/corda/testing/contracts/DummyContractV2.kt)
+[DummyContractV2.kt](https://github.com/corda/corda/blob/release/os/4.10/testing/core-test-utils/src/main/kotlin/net/corda/testing/contracts/DummyContractV2.kt)
 
 
 * Bank A instructs its node to accept the contract upgrade to `DummyContractV2` for the contract state.

--- a/content/en/platform/corda/4.10/community/json.md
+++ b/content/en/platform/corda/4.10/community/json.md
@@ -32,8 +32,8 @@ connection to the node (see “[Interacting with a node](clientrpc.md)”) then 
 The API is described in detail here:
 
 
-* [Kotlin API docs](https://api.corda.net/api/corda-os/4.8/html/api/kotlin/corda/net.corda.client.jackson/-jackson-support/index.html)
-* [JavaDoc](https://api.corda.net/api/corda-os/4.8/html/api/javadoc/net/corda/client/jackson/package-summary.html)
+* [Kotlin API docs](https://api.corda.net/api/corda-os/4.10/html/api/kotlin/corda/net.corda.client.jackson/-jackson-support/index.html)
+* [JavaDoc](https://api.corda.net/api/corda-os/4.10/html/api/javadoc/net/corda/client/jackson/package-summary.html)
 
 {{< tabs name="tabs-1" >}}
 {{% tab name="kotlin" %}}

--- a/content/en/platform/corda/4.10/community/key-concepts-vault.md
+++ b/content/en/platform/corda/4.10/community/key-concepts-vault.md
@@ -113,7 +113,7 @@ query soft locks associated with states as required by their CorDapp application
 
 ```
 
-[VaultService.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt)
+[VaultService.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/node/services/VaultService.kt)
 
 
 ### Querying the vault with `SoftLockingCondition`
@@ -134,7 +134,7 @@ By default, vault queries always include locked states in its result sets. Custo
 
 ```
 
-[QueryCriteria.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt)
+[QueryCriteria.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt)
 
 
 ### Explicit Usage

--- a/content/en/platform/corda/4.10/community/loadtesting.md
+++ b/content/en/platform/corda/4.10/community/loadtesting.md
@@ -54,7 +54,7 @@ rpcUser = {username = corda, password = not_blockchain, permissions = ["ALL"]}
 
 ```
 
-[loadtest-reference.conf](https://github.com/corda/corda/blob/release/os/4.8/tools/loadtest/src/main/resources/loadtest-reference.conf)
+[loadtest-reference.conf](https://github.com/corda/corda/blob/release/os/4.10/tools/loadtest/src/main/resources/loadtest-reference.conf)
 
 
 ## Running the load tests
@@ -103,7 +103,7 @@ There are a couple of top-level knobs to tweak test behaviour:
 
 ```
 
-[LoadTest.kt](https://github.com/corda/corda/blob/release/os/4.8/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTest.kt)
+[LoadTest.kt](https://github.com/corda/corda/blob/release/os/4.10/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTest.kt)
 
 The one thing of note is `disruptionPatterns`, which may be used to specify ways of disrupting the normal running of the load tests.
 
@@ -121,7 +121,7 @@ data class DisruptionSpec(
 
 ```
 
-[Disruption.kt](https://github.com/corda/corda/blob/release/os/4.8/tools/loadtest/src/main/kotlin/net/corda/loadtest/Disruption.kt)
+[Disruption.kt](https://github.com/corda/corda/blob/release/os/4.10/tools/loadtest/src/main/kotlin/net/corda/loadtest/Disruption.kt)
 
 Disruptions run concurrently in loops on randomly chosen nodes filtered by `nodeFilter` at somewhat random intervals.
 
@@ -135,7 +135,7 @@ fun strainCpu(parallelism: Int, durationSeconds: Int) = Disruption("Put strain o
 
 ```
 
-[Disruption.kt](https://github.com/corda/corda/blob/release/os/4.8/tools/loadtest/src/main/kotlin/net/corda/loadtest/Disruption.kt)
+[Disruption.kt](https://github.com/corda/corda/blob/release/os/4.10/tools/loadtest/src/main/kotlin/net/corda/loadtest/Disruption.kt)
 
 We can use this by specifying a `DisruptionSpec` in the load test’s `RunParameters`:
 
@@ -148,7 +148,7 @@ We can use this by specifying a `DisruptionSpec` in the load test’s `RunParame
 
 ```
 
-[Main.kt](https://github.com/corda/corda/blob/release/os/4.8/tools/loadtest/src/main/kotlin/net/corda/loadtest/Main.kt)
+[Main.kt](https://github.com/corda/corda/blob/release/os/4.10/tools/loadtest/src/main/kotlin/net/corda/loadtest/Main.kt)
 
 This means every 5-10 seconds at least one randomly chosen nodes’ cores will be spinning 100% for 10 seconds.
 
@@ -169,7 +169,7 @@ data class LoadTest<T, S>(
 
 ```
 
-[LoadTest.kt](https://github.com/corda/corda/blob/release/os/4.8/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTest.kt)
+[LoadTest.kt](https://github.com/corda/corda/blob/release/os/4.10/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTest.kt)
 
 `LoadTest` is parameterised over `T`, the unit of work, and `S`, the state type that aims to track remote node states. As an example let’s look at the Self Issue test. This test simply creates Cash Issues from nodes to themselves, and then checks the vault to see if the numbers add up:
 
@@ -191,7 +191,7 @@ val selfIssueTest = LoadTest<SelfIssueCommand, SelfIssueState>(
 
 ```
 
-[SelfIssueTest.kt](https://github.com/corda/corda/blob/release/os/4.8/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/SelfIssueTest.kt)
+[SelfIssueTest.kt](https://github.com/corda/corda/blob/release/os/4.10/tools/loadtest/src/main/kotlin/net/corda/loadtest/tests/SelfIssueTest.kt)
 
 The unit of work `SelfIssueCommand` simply holds an Issue and a handle to a node where the issue should be submitted. The `generate` method should provide a generator for these.
 
@@ -210,7 +210,7 @@ The `gatherRemoteState` function should check the actual remote nodes’ states 
 
 ```
 
-[LoadTest.kt](https://github.com/corda/corda/blob/release/os/4.8/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTest.kt)
+[LoadTest.kt](https://github.com/corda/corda/blob/release/os/4.10/tools/loadtest/src/main/kotlin/net/corda/loadtest/LoadTest.kt)
 
 `gatherRemoteState` gets as input handles to all the nodes, and the current predicted state, or null if this is the initial gathering.
 

--- a/content/en/platform/corda/4.10/community/network-bootstrapper.md
+++ b/content/en/platform/corda/4.10/community/network-bootstrapper.md
@@ -56,7 +56,7 @@ To bootstrap a test network:
 1. Download the [Corda Network Boostrapper](https://software.r3.com/artifactory/corda-releases/net/corda/corda-tools-network-bootstrapper) for the version of Corda you want the nodes to run.
 2. Create a directory containing a node config file (ending in “_node.conf”) for each node you want to create.
 3. Set “devMode” to `true`.
-4. Run the command `java -jar network-bootstrapper-4.8.jar --dir <nodes-root-dir>`.
+4. Run the command `java -jar network-bootstrapper-4.10.jar --dir <nodes-root-dir>`.
 
 If you were to run this command on a directory containing these files:
 
@@ -185,7 +185,7 @@ First, run the Network Bootstrapper as usual. Your network structure will look l
 
 Then, run the Network Bootstrapper again from the root directory:
 
-`java -jar network-bootstrapper-4.8.jar --dir <nodes-root-dir>`
+`java -jar network-bootstrapper-4.10.jar --dir <nodes-root-dir>`
 
 You will produce this result:
 
@@ -257,7 +257,7 @@ For example, you could take this pre-generated network:
 
 Then run the Network Bootstrapper again from the root directory:
 
-`java -jar network-bootstrapper-4.8.jar --dir <nodes-root-dir>`
+`java -jar network-bootstrapper-4.10.jar --dir <nodes-root-dir>`
 
 To produce:
 
@@ -307,11 +307,11 @@ You can use the `--minimum-platform-version`, `--max-message-size`, `--max-trans
 
 You can provide a file to override the network parameters using:
 
-`java -jar network-bootstrapper-4.8.jar --network-parameter-overrides=<path_to_file>`
+`java -jar network-bootstrapper-4.10.jar --network-parameter-overrides=<path_to_file>`
 
 Or the short form version:
 
-`java -jar network-bootstrapper-4.8.jar -n=<path_to_file>`
+`java -jar network-bootstrapper-4.10.jar -n=<path_to_file>`
 
 The network parameter overrides file is a HOCON file with several configuration fields, all of which are optional. If you don't provide a field, it will be ignored. If a field is not provided and you are bootstrapping a new network, a sensible default value will be used. If a field is not provided
 when you are updating an existing network, the value in the existing network parameters file will be used.

--- a/content/en/platform/corda/4.10/community/network-map.md
+++ b/content/en/platform/corda/4.10/community/network-map.md
@@ -229,7 +229,7 @@ data class ParametersUpdateInfo(
 
 ```
 
-[CordaRPCOps.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt)
+[CordaRPCOps.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt)
 
 
 ### Automatic Acceptance
@@ -273,7 +273,7 @@ data class NetworkParameters(
 
 ```
 
-[NetworkParameters.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/node/NetworkParameters.kt)
+[NetworkParameters.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/node/NetworkParameters.kt)
 
 This behaviour can be turned off by setting the optional node configuration property `networkParameterAcceptanceSettings.autoAcceptEnabled`
 to `false`. For example:

--- a/content/en/platform/corda/4.10/community/node-administration.md
+++ b/content/en/platform/corda/4.10/community/node-administration.md
@@ -313,13 +313,13 @@ The RPC call is also available as the `run nodeDiagnosticInfo` command executabl
 Here is a sample output displayed by the `run nodeDiagnosticInfo` command executed from the Corda shell:
 
 ```none
-version: "4.8"
+version: "4.10"
 revision: "d7e4a0050049be357999f57f69d8bca41a2b8274"
 platformVersion: 7
 vendor: "Corda Open Source"
 cordapps:
 - type: "Contract CorDapp"
-  name: "corda-finance-contracts-4.8"
+  name: "corda-finance-contracts-4.10"
   shortName: "Corda Finance Demo"
   minimumPlatformVersion: 1
   targetPlatformVersion: 4
@@ -328,7 +328,7 @@ cordapps:
   licence: "Open Source (Apache 2)"
   jarHash: "570EEB9DF4B43680586F3BE663F9C5844518BC2E410EAF9904E8DEE930B7E45C"
 - type: "Workflow CorDapp"
-  name: "corda-finance-workflows-4.8"
+  name: "corda-finance-workflows-4.10"
   shortName: "Corda Finance Demo"
   minimumPlatformVersion: 1
   targetPlatformVersion: 4

--- a/content/en/platform/corda/4.10/community/node-commandline.md
+++ b/content/en/platform/corda/4.10/community/node-commandline.md
@@ -63,7 +63,7 @@ Parameters:
 * `--skip-schema-creation`: Skips the default database migration step.
 
 {{< note >}}
-Node `initial-registration` now includes the creation of `identity-private-key` keystore alias. For more information, see [node folder structure](node-structure.md). Previously, only `cordaclientca` and `cordaclienttls` aliases were created during `initial-registration`, while `identity-private-key` was generated on demand on the first node run. Hence, in Corda 4.8 the content of `nodekeystore.jks` is never altered during a regular node run (except for `devMode = true`, where the certificates directory can be filled with pre-configured keystores).
+Node `initial-registration` now includes the creation of `identity-private-key` keystore alias. For more information, see [node folder structure](node-structure.md). Previously, only `cordaclientca` and `cordaclienttls` aliases were created during `initial-registration`, while `identity-private-key` was generated on demand on the first node run. Hence, in Corda 4.10 the content of `nodekeystore.jks` is never altered during a regular node run (except for `devMode = true`, where the certificates directory can be filled with pre-configured keystores).
 {{< /note >}}
 
 `run-migration-scripts`: From version 4.6, a Corda node can no longer modify/create schema on the fly in normal run mode - schema setup or changes must be

--- a/content/en/platform/corda/4.10/community/node-naming.md
+++ b/content/en/platform/corda/4.10/community/node-naming.md
@@ -57,7 +57,7 @@ The name must also obey the following constraints:
 
 
 
-* The `country` attribute is a valid *ISO 3166-1<https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>* two letter code in upper-case. See the list of [defined country codes](https://github.com/corda/corda/blob/release/os/4.8/tools/worldmap/src/main/resources/net/corda/worldmap/cities.txt).
+* The `country` attribute is a valid *ISO 3166-1<https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>* two letter code in upper-case. See the list of [defined country codes](https://github.com/corda/corda/blob/release/os/4.10/tools/worldmap/src/main/resources/net/corda/worldmap/cities.txt).
 * The `organisation` field of the name obeys the following constraints:
 
     * Has at least two letters

--- a/content/en/platform/corda/4.10/community/reissuing-states.md
+++ b/content/en/platform/corda/4.10/community/reissuing-states.md
@@ -40,7 +40,7 @@ See [Encumbrances](key-concepts-contracts.html#encumbrances) for more informatio
 In addition, a single trusted issuing party is allowed to reissue multiple fungible states at once, provided that all these states are of the same type. For example, you can issue at once a number of tokens with different quantities but with the same `TokenType` and issued by the same party.
 
 {{< note >}}
-This functionality is part of Corda Open Source 4.8 and can be fully leveraged by Corda Enterprise Edition 4.8 users as well.
+This functionality is part of Corda Open Source 4.10 and can be fully leveraged by Corda Enterprise Edition 4.8 users as well.
 {{< /note >}}
 
 ## How it works

--- a/content/en/platform/corda/4.10/community/running-a-notary.md
+++ b/content/en/platform/corda/4.10/community/running-a-notary.md
@@ -52,14 +52,14 @@ for more details.
 ## Crash fault-tolerant (experimental)
 
 Corda provides a prototype [Raft-based](http://atomix.io/) highly available notary implementation. You can try it out on our
-[notary demo](https://github.com/corda/corda/blob/release/os/4.8/samples/notary-demo) page. Note that it has known limitations
+[notary demo](https://github.com/corda/corda/blob/release/os/4.10/samples/notary-demo) page. Note that it has known limitations
 and is not recommended for production use.
 
 
 ## Byzantine fault-tolerant (experimental)
 
 A prototype BFT notary implementation based on [BFT-Smart](https://github.com/bft-smart/library) is available. You can
-try it out on our [notary demo](https://github.com/corda/corda/blob/release/os/4.8/samples/notary-demo) page. Note that it
+try it out on our [notary demo](https://github.com/corda/corda/blob/release/os/4.10/samples/notary-demo) page. Note that it
 is still experimental and there is active work ongoing for a production ready solution. Additionally, BFT-Smart requires Java
 serialization which is disabled by default in Corda due to security risks, and it will only work in dev mode where this can
 be customised.

--- a/content/en/platform/corda/4.10/community/secure-coding-guidelines.md
+++ b/content/en/platform/corda/4.10/community/secure-coding-guidelines.md
@@ -63,4 +63,4 @@ Make sure your contracts are secure. Check that:
 ## Related Content
 Learn more about:
 * [Writing flows]({{< relref "../enterprise/flow-state-machines.md" >}})
-* [Contracts]({{< relref "../../../../../../en/platform/corda/4.8/enterprise/cordapps/api-contracts.md" >}})
+* [Contracts]({{< relref "../enterprise/cordapps/api-contracts.md" >}})

--- a/content/en/platform/corda/4.10/community/setting-up-a-dynamic-compatibility-zone.md
+++ b/content/en/platform/corda/4.10/community/setting-up-a-dynamic-compatibility-zone.md
@@ -193,11 +193,10 @@ signedParams.open().copyTo(Paths.get("/some/path"))
 
 {{< /tabs >}}
 
-Each individual parameter is documented in [the JavaDocs/KDocs for the NetworkParameters class](https://docs.corda.net/api/kotlin/corda/net.corda.core.node/-network-parameters/index.html). The network map
+Each individual parameter is documented in [the JavaDocs/KDocs for the NetworkParameters class](../../../../../en/api-ref/corda/4.10/community/kotlin/corda/net.corda.core.node/-network-parameters/index.html). The network map
 certificate is usually chained off the root certificate, and can be created according to the instructions above. Each
 time the zone parameters are changed, the epoch should be incremented. Epochs are essentially version numbers for the
 parameters, and they therefore cannot go backwards. Once saved, the new parameters can be served by the network map server.
-
 
 ### Selecting parameter values
 

--- a/content/en/platform/corda/4.10/community/shell.md
+++ b/content/en/platform/corda/4.10/community/shell.md
@@ -477,7 +477,7 @@ Use the different flow commands available to make changes on the ledger. You can
 
 #### Query flow data
 
-The shell can be used to query flow data. For more information on the types of data that can be queried and instructions for doing so, see the documentation on [Querying flow data](../../4.8/enterprise/node/operating/querying-flow-data.html#querying-flow-data-via-the-node-shell).
+The shell can be used to query flow data. For more information on the types of data that can be queried and instructions for doing so, see the documentation on [Querying flow data]({{< relref "../enterprise/node/operating/querying-flow-data.md#querying-flow-data-via-the-node-shell" >}}).
 
 
 #### Start a flow

--- a/content/en/platform/corda/4.10/community/shell.md
+++ b/content/en/platform/corda/4.10/community/shell.md
@@ -232,7 +232,7 @@ You can use the shell to:
 The shell interacts with the node by issuing RPCs (remote procedure calls). You make an RPC from the shell by typing `run`, followed by the name of the desired RPC method.
 
 You can find a list of the available RPC methods
-[here](https://docs.corda.net/api/kotlin/corda/net.corda.core.messaging/-corda-r-p-c-ops/index.html).
+[here](../../../../../en/api-ref/corda/4.10/community/kotlin/corda/net.corda.core.messaging/-corda-r-p-c-ops/index.html).
 
 Some RPCs return a stream of events that will be shown on screen until you press Ctrl-C.
 

--- a/content/en/platform/corda/4.10/community/token-sdk-introduction.md
+++ b/content/en/platform/corda/4.10/community/token-sdk-introduction.md
@@ -61,7 +61,7 @@ In V1.2.2, a new [Token Selection](token-selection.md) feature allows the except
 To upgrade the Tokens SDK:
 
 {{< warning >}}
-Before upgrading, make sure the platform database schema is properly migrated and the changelog syncrhonised - consult the [upgrade documentation for Corda 4.8](app-upgrade-notes.md). If you have not migrated the schema, the Tokens SDK may not upgrade correctly.
+Before upgrading, make sure the platform database schema is properly migrated and the changelog syncrhonised - consult the [upgrade documentation for Corda 4.10]({{< relref "app-upgrade-notes.md" >}}). If you have not migrated the schema, the Tokens SDK may not upgrade correctly.
 {{< /warning >}}
 
 1. Change the V number (version number) in your CorDapp's relevant Gradle file to the version you are upgrading to - such as 1.2.2

--- a/content/en/platform/corda/4.10/community/upgrading-cordapps.md
+++ b/content/en/platform/corda/4.10/community/upgrading-cordapps.md
@@ -339,7 +339,7 @@ There are two types of contract/state upgrade:
 * *Explicit:* By creating a special *contract upgrade transaction* and getting all participants of a state to sign it using the
 contract upgrade flows.
 
-The general recommendation for Corda 4.8 is to use **implicit** upgrades for the reasons described [here](api-contract-constraints.html#implicit-vs-explicit-upgrades).
+The general recommendation for Corda 4.10 is to use **implicit** upgrades for the reasons described [here](api-contract-constraints.html#implicit-vs-explicit-upgrades).
 
 
 

--- a/content/en/platform/corda/4.10/community/versioning.md
+++ b/content/en/platform/corda/4.10/community/versioning.md
@@ -158,7 +158,7 @@ The following error message will be received before the node shuts down:
 ```
 [ERROR] 17:10:11+0100 [main] internal.NodeStartupLogging. - Invalid Cordapps found, that couldn't be loaded:
 [Problem: CorDapp requires minimumPlatformVersion: 7, but was: 2 in Cordapp
-file:/corda-open-source/samples/bank-of-corda-demo/build/nodes/BankOfCorda/cordapps/bank-of-corda-demo-4.8-SNAPSHOT.jar
+file:/corda-open-source/samples/bank-of-corda-demo/build/nodes/BankOfCorda/cordapps/bank-of-corda-demo-4.10-SNAPSHOT.jar
 ```
 
 For more information on how to address this, see the [Release new CorDapp versions](upgrading-cordapps.md) page.

--- a/content/en/platform/corda/4.10/community/writing-a-cordapp.md
+++ b/content/en/platform/corda/4.10/community/writing-a-cordapp.md
@@ -52,7 +52,7 @@ You should base your project on one of the following templates:
 * [Kotlin Template CorDapp](https://github.com/corda/cordapp-template-kotlin) (for CorDapps written in Kotlin)
 
 Please use the branch of the template that corresponds to the major version of Corda you are using. For example,
-someone building a CorDapp on Corda 4.8 should use the `release-V4` branch of the template.
+someone building a CorDapp on Corda 4.10 should use the `release-V4` branch of the template.
 
 
 ### Build system

--- a/content/en/platform/corda/4.10/enterprise/apps/bankinabox/back-end-guide.md
+++ b/content/en/platform/corda/4.10/enterprise/apps/bankinabox/back-end-guide.md
@@ -121,7 +121,7 @@ The method checks that the account has sufficient funds - in either the account 
 
 #### Custom serialization
 
-Corda uses the [Kryo serializer](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/serialization-index.md) to serialize objects on the call stack when suspending flows. There are known issues serializing JPA entity objects, particularly if they use one to many relationships or other complex structures. One approach to overcome this is to map entity objects to data classes, referred to as Data Transfer Objects (DTOs), for use within flows. Another approach is to implement custom serializers that generate the serialization for Kryo.
+Corda uses the [Kryo serializer]({{< relref "../../serialization-index.md" >}}) to serialize objects on the call stack when suspending flows. There are known issues serializing JPA entity objects, particularly if they use one to many relationships or other complex structures. One approach to overcome this is to map entity objects to data classes, referred to as Data Transfer Objects (DTOs), for use within flows. Another approach is to implement custom serializers that generate the serialization for Kryo.
 
 A custom serializer for a JPA entity can be specified with the `DefaultSerializer` annotation:
 
@@ -184,7 +184,7 @@ To create a new customer, use the `CreateCustomerFlow`. This flow also adds pers
 * `contactNumber`: Customer phone number.
 * `emailAddress`: Customer email address.
 * `postCode`: Post code of customer's address.
-* `attachments`: List of `SecureHash`, `String` pairs with references to the Corda attachments of additional customer documentation. For more information on the standard process for uploading attachments to Corda, see the documentation on [CorDapp Contract Attachments](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/cordapp-build-systems.md).
+* `attachments`: List of `SecureHash`, `String` pairs with references to the Corda attachments of additional customer documentation. For more information on the standard process for uploading attachments to Corda, see the documentation on [CorDapp Contract Attachments]({{< relref "../../cordapps/cordapp-build-systems.md" >}}).
 
 This flows returns `UUID`, the customer ID.
 
@@ -324,11 +324,11 @@ subFlow(ApproveOverdraftFlow(accountId, amount))
 
 ## Loans
 
-The Bank in a Box application uses [Oracles](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/key-concepts-oracles.md) in various contexts, one of which is in the issuance of loans. A dummy Oracle is used to call external services based on a customer ID and sign off on the loan. The response is then embedded in the transaction that issues the loan. This mimics a real-life scenario where a bank calls a rating provider before giving a customer a loan.
+The Bank in a Box application uses [Oracles]({{< relref "../../key-concepts-oracles.md" >}}) in various contexts, one of which is in the issuance of loans. A dummy Oracle is used to call external services based on a customer ID and sign off on the loan. The response is then embedded in the transaction that issues the loan. This mimics a real-life scenario where a bank calls a rating provider before giving a customer a loan.
 
-Oracle signatures use [partial Merkle tree signing](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/key-concepts-tearoffs.md), which provides privacy for the transaction. In this way, the external party present in the loan issuance transaction can only see the contents of the transaction that they must confirm before signing the transaction.
+Oracle signatures use [partial Merkle tree signing]({{< relref "../../key-concepts-tearoffs.mdl#merkle-trees-on-corda" >}}), which provides privacy for the transaction. In this way, the external party present in the loan issuance transaction can only see the contents of the transaction that they must confirm before signing the transaction.
 
-When a loan is issued, money is transferred to the customer's current account. In the background, this transaction uses [Corda scheduled states](../../../enterprise/event-scheduling.html#how-to-implement-scheduled-events) to create a recurring payment for that loan, into the loan account.
+When a loan is issued, money is transferred to the customer's current account. In the background, this transaction uses [Corda scheduled states]({{< relref "../../../enterprise/event-scheduling.md#how-to-implement-scheduled-events" >}}) to create a recurring payment for that loan, into the loan account.
 
 ### Business logic
 
@@ -728,7 +728,7 @@ val signedTx = subFlow(DepositFiatFlow(accountId, amount))
 
 ## Payments
 
-As noted in the [Loans](#loans) section, [Corda scheduled states](../../../enterprise/event-scheduling.html#implementing-scheduled-events) are utilised in Bank in a Box to create recurring payments that start on a given date and are executed in a specific time period.
+As noted in the [Loans](#loans) section, [Corda scheduled states]({{< relref "../../../enterprise/event-scheduling.md#implementing-scheduled-events" >}}) are utilised in Bank in a Box to create recurring payments that start on a given date and are executed in a specific time period.
 
 Payments in Bank in a Box are also a good example of how CorDapps can be integrated with external systems.
 
@@ -741,7 +741,7 @@ The business logic behind Bank in a Box payments is explained below, addressing:
 
 #### Deduplicating payment logs
 
-In Corda, notaries prevent the double spending of contract states but this naturally excludes off-ledger systems. Instead, Corda provides a <a href="https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/api-flows.md">`FlowExternalOperation`</a> that is executed with a `deduplicationId`, allowing for custom handling of duplicate runs. Each recurring payment execution is logged and duplicate logs can be avoided by creating the payment log instance within a subclass of `FlowExternalOperation`. 
+In Corda, notaries prevent the double spending of contract states but this naturally excludes off-ledger systems. Instead, Corda provides a [FlowExternalOperation]({{< relref "../../cordapps/api-flows.md" >}})  that is executed with a `deduplicationId`, allowing for custom handling of duplicate runs. Each recurring payment execution is logged and duplicate logs can be avoided by creating the payment log instance within a subclass of `FlowExternalOperation`. 
 
 The skeleton `CreateRecurringPaymentLogOperation` is as follows:
 

--- a/content/en/platform/corda/4.10/enterprise/apps/bankinabox/getting-started.md
+++ b/content/en/platform/corda/4.10/enterprise/apps/bankinabox/getting-started.md
@@ -18,7 +18,7 @@ Follow this guide to set up Bank in a Box so you can start testing its features 
 
 ## Prerequisites
 
-Testing the Bank in a Box CorDapp or building your own banking CorDapp both require some Corda programming knowledge. If you are new to Corda, read about [Corda key concepts](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/key-concepts.md) and [CorDapps](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/cordapp-overview.md) to get up to speed.
+Testing the Bank in a Box CorDapp or building your own banking CorDapp both require some Corda programming knowledge. If you are new to Corda, read about [Corda key concepts]({{< relref "../../about-corda/corda-key-concepts.md" >}}) and [CorDapps]({{< relref "../../cordapps/cordapp-overview.md" >}}) to get up to speed.
 
 Follow the general instructions for [Getting set up]({{< relref "../../cordapps/getting-set-up.md" >}}) to develop CorDapps once you are ready to get started with Bank in a Box.
 
@@ -149,7 +149,7 @@ The following projects must be built to run Bank in a Box:
 - `webservices`
 
 
-To build your JAR files from source code, `cd` into the root of [the repository cloned above](#clone-the-bank-in-a-box-repository) and execute the following commands:
+To build your JAR files from source code, `cd` into the root of [the repository cloned above]({{< relref "#clone-the-bank-in-a-box-repository" >}}) and execute the following commands:
 
 `./gradlew workflows:jar`
 

--- a/content/en/platform/corda/4.10/enterprise/apps/bankinabox/getting-started.md
+++ b/content/en/platform/corda/4.10/enterprise/apps/bankinabox/getting-started.md
@@ -36,7 +36,7 @@ You will also need the following to work on Bank in a Box:
 
 Bank in a Box has the following computational requirements:
 
-* Memory: 6 Gibibytes
+* Memory: 6 Gigabytes
 * CPU: 2000m (2 full cores)
 
 ### Notes on Kubernetes cluster setup

--- a/content/en/platform/corda/4.10/enterprise/contract-upgrade.md
+++ b/content/en/platform/corda/4.10/enterprise/contract-upgrade.md
@@ -61,7 +61,7 @@ class Authorise(
 
 ```
 
-[ContractUpgradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt)
+[ContractUpgradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt)
 
 ```kotlin
 @StartableByRPC
@@ -71,7 +71,7 @@ class Deauthorise(val stateRef: StateRef) : FlowLogic<Void?>() {
 
 ```
 
-[ContractUpgradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt)
+[ContractUpgradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt)
 
 
 ## Proposing an upgrade

--- a/content/en/platform/corda/4.10/enterprise/cordapps/api-confidential-identity.md
+++ b/content/en/platform/corda/4.10/enterprise/cordapps/api-confidential-identity.md
@@ -45,7 +45,7 @@ counterparty we want to exchange confidential identities with. It returns a mapp
 and the counterparty to their new confidential identities. In the future, this flow will be extended to handle swapping
 identities with multiple parties at once.
 
-You can see an example of using `SwapIdentitiesFlow` in <a href="../../../../../../en/api-ref/corda/4.10/community/kotlin/corda/net.corda.finance.flows/-two-party-deal-flow/index.md">`TwoPartyDealFlow.kt`</a> .
+You can see an example of using `SwapIdentitiesFlow` in [TwoPartyDealFlow.kt](../../../../../../en/api-ref/corda/4.10/community/kotlin/corda/net.corda.finance.flows/-two-party-deal-flow/index.md).
 `SwapIdentitiesFlow` goes through the following key steps:
 
 * Generate a new confidential identity from our well-known identity

--- a/content/en/platform/corda/4.10/enterprise/cordapps/cordapp-upgradeability.md
+++ b/content/en/platform/corda/4.10/enterprise/cordapps/cordapp-upgradeability.md
@@ -23,18 +23,18 @@ The following guarantees are made for CorDapps running on Corda 4.0
 * Compliant CorDapps compiled with previous versions of Corda (from 3.0) will execute without change on Corda 4.0{{< note >}}
 by “compliant”, we mean CorDapps that do not utilise Corda internal, non-stable or other non-committed public Corda APIs.{{< /note >}}
 Recommendation: security hardening changes in flow processing, specifically the `FinalityFlow`, recommend upgrading existing CorDapp
-receiver flows to use the new APIs and thus opting in to platform version 4. See [Step 5. Security: Upgrade your use of FinalityFlow](../app-upgrade-notes.html#5-improve-the-security-of-your-cordapp-by-upgrading-how-you-use-finalityflow) for more information.
+receiver flows to use the new APIs and thus opting in to platform version 4. See [Step 5. Security: Upgrade your use of FinalityFlow]({{< relref "../app-upgrade-notes.md#5-improve-the-security-of-your-cordapp-by-upgrading-how-you-use-finalityflow" >}}) for more information.
 * All constraint types (hash, CZ whitelisted, signature) are consumable within the same transaction if there is an associated contract attachment that satisfies all of them.
-* CorDapp Contract states generated on ledger using hash constraints are not directly migratable to signature constraints in this release.
+* CorDapp Contract states generated on ledger using hash constraints are not directly migrateable to signature constraints in this release.
 Your compatibility zone operator may whitelist a JAR previously used to issue hash constrained states, and then you can follow the manual
-process described in the paragraph below to migrate these to signature constraints. See [CorDapp constraints migration](cordapp-constraint-migration.md) for more information.
+process described in the paragraph below to migrate these to signature constraints. See [CorDapp constraints migration]({{< relref "cordapp-constraint-migration.md" >}}) for more information.
 * CorDapp Contract states generated on ledger using CZ whitelisted constraints are migratable to signature constraints using a manual process
-that requires programmatic code changes. See [CZ whitelisted constraints migration](cordapp-constraint-migration.html#migrating-cz-whitelisted-constraints) for more information.
-* Explicit Contract Upgrades are only supported for hash and CZ whitelisted constraint types. See [Performing explicit contract and state upgrades](upgrading-cordapps.html#performing-explicit-contract-and-state-upgrades) for more information.
+that requires programmatic code changes. See [CZ whitelisted constraints migration]({{< relref "cordapp-constraint-migration.md#migrating-cz-whitelisted-constraints" >}}) for more information.
+* Explicit Contract Upgrades are only supported for hash and CZ whitelisted constraint types. See [Performing explicit contract and state upgrades]({{< relref "upgrading-cordapps.md#performing-explicit-contract-and-state-upgrades" >}}) for more information.
 * CorDapp contract attachments are not trusted from remote peers over the p2p network for the purpose of transaction verification.
 A node operator must locally install *all* versions of a Contract attachment to be able to resolve a chain of contract states from its original version.
 The RPC `uploadAttachment` mechanism can be used to achieve this (as well as conventional loading of a CorDapp by installing it in the nodes /cordapp directory).
-See [Installing the CorDapp JAR](cordapp-build-systems.html#create-the-cordapp-jar) and [CorDapp Contract Attachments](cordapp-build-systems.html#cordapp-contract-attachments) for more information.
+See [Installing the CorDapp JAR]({{< relref "cordapp-build-systems.md#create-the-cordapp-jar" >}}) and [CorDapp Contract Attachments]({{< relref "cordapp-build-systems.md#cordapp-contract-attachments" >}}) for more information.
 * CorDapp contract attachment classloader isolation has some important side-effects and edge cases to consider:
 * Contract attachments should include all 3rd party library dependencies in the same packaged JAR - we call this a “Fat JAR”,
 meaning that all dependencies are resolvable by the classloader by only loading a single JAR.
@@ -59,9 +59,9 @@ The following additional capabilities are under consideration for delivery in fo
 
 
 * CorDapp Contract states generated on ledger using hash constraints will be automatically migrated to signature constraints when building new transactions
-where the latest installed contract Jar is signed as per [CorDapp Jar signing](cordapp-build-systems.html#sign-the-cordapp).
+where the latest installed contract Jar is signed as per [CorDapp Jar signing]({{< relref "cordapp-build-systems.md#sign-the-cordapp" >}}).
 * CorDapp Contract states generated on ledger using CZ whitelisted constraints will be automatically migrated to signature constraints when building new transactions
-where the latest installed contract Jar is signed as per [CorDapp Jar signing](cordapp-build-systems.html#sign-the-cordapp).
+where the latest installed contract Jar is signed as per [CorDapp Jar signing]({{< relref "cordapp-build-systems.md#sign-the-cordapp" >}}).
 * Explicit Contract Upgrades will be supported for all constraint types: hash, CZ whitelisted and signature.
 In practice, it should only be necessary to upgrade from hash or CZ whitelisted to new signature constrained contract types.
 signature constrained Contracts are upgradeable seamlessly (through built in serialization and code signing controls) without requiring explicit upgrades.

--- a/content/en/platform/corda/4.10/enterprise/key-concepts-vault.md
+++ b/content/en/platform/corda/4.10/enterprise/key-concepts-vault.md
@@ -135,7 +135,7 @@ By default, vault queries always include locked states in its result sets. Custo
 
 ```
 
-[QueryCriteria.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt)
+[QueryCriteria.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/node/services/vault/QueryCriteria.kt)
 
 
 ### Explicit Usage

--- a/content/en/platform/corda/4.10/enterprise/node-docker-deployments.md
+++ b/content/en/platform/corda/4.10/enterprise/node-docker-deployments.md
@@ -90,7 +90,7 @@ It is possible to utilize the image to automatically generate a sensible minimal
 Requirements: A Compatibility Zone, the Zone Trust Root and authorisation to join said Zone.
 
 {{< /note >}}
-It is possible to use the image to automate the process of joining an existing Zone as detailed [here]({{< relref "../../../../../en/platform/corda/4.8/enterprise/network/compatibility-zones.md" >}})
+It is possible to use the image to automate the process of joining an existing Zone as detailed [here]({{< relref "network/compatibility-zones.md" >}})
 
 The first step is to obtain the Zone Trust Root, and place it within a directory. In the below example, the Trust Root is stored at `/home/user/docker/certificates/network-root-truststore.jks`.
 It is possible to configure the name of the Trust Root file by setting the `TRUST_STORE_NAME` environment variable in the container.

--- a/content/en/platform/corda/4.10/enterprise/node/deploy/generating-a-node-cordform.md
+++ b/content/en/platform/corda/4.10/enterprise/node/deploy/generating-a-node-cordform.md
@@ -222,7 +222,7 @@ running the bootstrapper.
 
 ## Package namespace ownership
 
-To configure [package namespace ownership](../../../../../../../en/platform/corda/4.8/enterprise/node/deploy/env-dev.html#package-namespace-ownership), use the optional `networkParameterOverrides` and `packageOwnership` blocks, in a similar way to how the configuration file is used by the [Network Bootstrapper]({{< relref "../../network-bootstrapper.md" >}}) tool. For example:
+To configure [package namespace ownership]({{< relref "env-dev.md#package-namespace-ownership" >}}), use the optional `networkParameterOverrides` and `packageOwnership` blocks, in a similar way to how the configuration file is used by the [Network Bootstrapper]({{< relref "../../network-bootstrapper.md" >}}) tool. For example:
 
 ```groovy
 task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
@@ -300,7 +300,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
 ```
 ## Optional migration step
 
-If you are migrating your database schema from an older Corda version to Corda 4.8, you must add the following parameter to the node section in the `build.gradle` and set it to `true`, as follows:
+If you are migrating your database schema from an older Corda version to Corda 4.10, you must add the following parameter to the node section in the `build.gradle` and set it to `true`, as follows:
 
 ```
         runSchemaMigration = true

--- a/content/en/platform/corda/4.10/enterprise/node/deploy/running-a-node.md
+++ b/content/en/platform/corda/4.10/enterprise/node/deploy/running-a-node.md
@@ -175,7 +175,7 @@ Parameters:
 * `--skip-schema-creation`: Skips the default database migration step.
 
 {{< note >}}
-Node `initial-registration` now includes the creation of `identity-private-key` keystore alias. For more information, see [node folder structure]({{< relref "../../node/setup/node-structure.md" >}}). Previously, only `cordaclientca` and `cordaclienttls` aliases were created during `initial-registration`, while `identity-private-key` was generated on demand on the first node run. Hence, in Corda 4.8 the content of `nodekeystore.jks` is never altered during a regular node run (except for `devMode = true`, where the certificates directory can be filled with pre-configured keystores).
+Node `initial-registration` now includes the creation of `identity-private-key` keystore alias. For more information, see [node folder structure]({{< relref "../../node/setup/node-structure.md" >}}). Previously, only `cordaclientca` and `cordaclienttls` aliases were created during `initial-registration`, while `identity-private-key` was generated on demand on the first node run. Hence, in Corda 4.10 the content of `nodekeystore.jks` is never altered during a regular node run (except for `devMode = true`, where the certificates directory can be filled with pre-configured keystores).
 {{< /note >}}
 `run-migration-scripts`: From version 4.6, a Corda node can no longer modify/create schema on the fly in normal run mode - schema setup or changes must be
 applied deliberately using this sub-command. It runs the database migration script for the requested schema set defined in the following parameters. Once it creates or modifies the schema(s), the sub-command will exit.

--- a/content/en/platform/corda/4.10/enterprise/node/operating/shell.md
+++ b/content/en/platform/corda/4.10/enterprise/node/operating/shell.md
@@ -262,7 +262,7 @@ You can use the shell to:
 The shell interacts with the node by issuing RPCs (remote procedure calls). You make an RPC from the shell by typing `run`, followed by the name of the desired RPC method.
 
 You can find a list of the available RPC methods
-[here](https://docs.corda.net/api/kotlin/corda/net.corda.core.messaging/-corda-r-p-c-ops/index.html).
+[here](../../../../../en/api-ref/corda/4.10/community/kotlin/corda/net.corda.core.messaging/-corda-r-p-c-ops/index.html).
 
 Some RPCs return a stream of events that will be shown on screen until you press Ctrl-C.
 

--- a/content/en/platform/corda/4.10/enterprise/node/setup/node-naming.md
+++ b/content/en/platform/corda/4.10/enterprise/node/setup/node-naming.md
@@ -52,7 +52,7 @@ The name must also obey the following constraints:
 
 
 
-* The `country` attribute is a valid *ISO 3166-1<https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>* two letter code in upper-case. See the list of [defined country codes](https://github.com/corda/corda/blob/release/os/4.8/tools/worldmap/src/main/resources/net/corda/worldmap/cities.txt).
+* The `country` attribute is a valid *ISO 3166-1<https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>* two letter code in upper-case. See the list of [defined country codes](https://github.com/corda/corda/blob/release/os/4.10/tools/worldmap/src/main/resources/net/corda/worldmap/cities.txt).
 * The `organisation` field of the name obeys the following constraints:
 
     * Has at least two letters

--- a/content/en/platform/corda/4.10/enterprise/notary/running-a-notary.md
+++ b/content/en/platform/corda/4.10/enterprise/notary/running-a-notary.md
@@ -52,14 +52,14 @@ for more details.
 ## Crash fault-tolerant (experimental)
 
 Corda provides a prototype [Raft-based](http://atomix.io/) highly available notary implementation. You can try it out on our
-[notary demo](https://github.com/corda/corda/blob/release/os/4.8/samples/notary-demo) page. Note that it has known limitations
+[notary demo](https://github.com/corda/corda/blob/release/os/4.10/samples/notary-demo) page. Note that it has known limitations
 and is not recommended for production use.
 
 
 ## Byzantine fault-tolerant (experimental)
 
 A prototype BFT notary implementation based on [BFT-Smart](https://github.com/bft-smart/library) is available. You can
-try it out on our [notary demo](https://github.com/corda/corda/blob/release/os/4.8/samples/notary-demo) page. Note that it
+try it out on our [notary demo](https://github.com/corda/corda/blob/release/os/4.10/samples/notary-demo) page. Note that it
 is still experimental and there is active work ongoing for a production ready solution. Additionally, BFT-Smart requires Java
 serialization which is disabled by default in Corda due to security risks, and it will only work in dev mode where this can
 be customised.

--- a/content/en/platform/corda/4.10/enterprise/operations/deployment/deployment-kubernetes.md
+++ b/content/en/platform/corda/4.10/enterprise/operations/deployment/deployment-kubernetes.md
@@ -560,4 +560,4 @@ kubectl get svc --namespace cenm nmap --template "{{ range (index .status.loadBa
 
 ## Appendix A: Docker Images
 
-Visit the [platform support matrix](../../platform-support-matrix.html#docker-images) for information on Corda Docker Images for version 4.8.
+Visit the [platform support matrix](../../platform-support-matrix.html#docker-images) for information on Corda Docker Images for version 4.10.

--- a/content/en/platform/corda/4.7/enterprise/apps/bankinabox/back-end-guide.md
+++ b/content/en/platform/corda/4.7/enterprise/apps/bankinabox/back-end-guide.md
@@ -121,7 +121,7 @@ The method checks that the account has sufficient funds - in either the account 
 
 #### Custom serialization
 
-Corda uses the [Kryo serializer](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/serialization-index.md) to serialize objects on the call stack when suspending flows. There are known issues serializing JPA entity objects, particularly if they use one to many relationships or other complex structures. One approach to overcome this is to map entity objects to data classes, referred to as Data Transfer Objects (DTOs), for use within flows. Another approach is to implement custom serializers that generate the serialization for Kryo.
+Corda uses the [Kryo serializer]({{< relref "../../serialization-index.md" >}}) to serialize objects on the call stack when suspending flows. There are known issues serializing JPA entity objects, particularly if they use one to many relationships or other complex structures. One approach to overcome this is to map entity objects to data classes, referred to as Data Transfer Objects (DTOs), for use within flows. Another approach is to implement custom serializers that generate the serialization for Kryo.
 
 A custom serializer for a JPA entity can be specified with the `DefaultSerializer` annotation:
 
@@ -184,7 +184,7 @@ To create a new customer, use the `CreateCustomerFlow`. This flow also adds pers
 * `contactNumber`: Customer phone number.
 * `emailAddress`: Customer email address.
 * `postCode`: Post code of customer's address.
-* `attachments`: List of `SecureHash`, `String` pairs with references to the Corda attachments of additional customer documentation. For more information on the standard process for uploading attachments to Corda, see the documentation on [CorDapp Contract Attachments](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/cordapp-build-systems.md).
+* `attachments`: List of `SecureHash`, `String` pairs with references to the Corda attachments of additional customer documentation. For more information on the standard process for uploading attachments to Corda, see the documentation on [CorDapp Contract Attachments]({{< relref "../../cordapps/cordapp-build-systems.md" >}}).
 
 This flows returns `UUID`, the customer ID.
 
@@ -324,11 +324,11 @@ subFlow(ApproveOverdraftFlow(accountId, amount))
 
 ## Loans
 
-The Bank in a Box application uses [Oracles](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/key-concepts-oracles.md) in various contexts, one of which is in the issuance of loans. A dummy Oracle is used to call external services based on a customer ID and sign off on the loan. The response is then embedded in the transaction that issues the loan. This mimics a real-life scenario where a bank calls a rating provider before giving a customer a loan.
+The Bank in a Box application uses [Oracles]({{< relref "../../key-concepts-oracles.md" >}}) in various contexts, one of which is in the issuance of loans. A dummy Oracle is used to call external services based on a customer ID and sign off on the loan. The response is then embedded in the transaction that issues the loan. This mimics a real-life scenario where a bank calls a rating provider before giving a customer a loan.
 
-Oracle signatures use [partial Merkle tree signing](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/key-concepts-tearoffs.md), which provides privacy for the transaction. In this way, the external party present in the loan issuance transaction can only see the contents of the transaction that they must confirm before signing the transaction.
+Oracle signatures use [partial Merkle tree signing]({{< relref "../../key-concepts-tearoffs.md#transaction-merkle-trees" >}}), which provides privacy for the transaction. In this way, the external party present in the loan issuance transaction can only see the contents of the transaction that they must confirm before signing the transaction.
 
-When a loan is issued, money is transferred to the customer's current account. In the background, this transaction uses [Corda scheduled states](../../../enterprise/event-scheduling.html#how-to-implement-scheduled-events) to create a recurring payment for that loan, into the loan account.
+When a loan is issued, money is transferred to the customer's current account. In the background, this transaction uses [Corda scheduled states]({{< relref "../../event-scheduling.md#implementing-scheduled-events" >}}) to create a recurring payment for that loan, into the loan account.
 
 ### Business logic
 
@@ -741,7 +741,7 @@ The business logic behind Bank in a Box payments is explained below, addressing:
 
 #### Deduplicating payment logs
 
-In Corda, notaries prevent the double spending of contract states but this naturally excludes off-ledger systems. Instead, Corda provides a <a href="https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/api-flows.md">`FlowExternalOperation`</a> that is executed with a `deduplicationId`, allowing for custom handling of duplicate runs. Each recurring payment execution is logged and duplicate logs can be avoided by creating the payment log instance within a subclass of `FlowExternalOperation`. 
+In Corda, notaries prevent the double spending of contract states but this naturally excludes off-ledger systems. Instead, Corda provides a [FlowExternalOperation]({{< relref "../../cordapps/api-flows.md" >}}) that is executed with a `deduplicationId`, allowing for custom handling of duplicate runs. Each recurring payment execution is logged and duplicate logs can be avoided by creating the payment log instance within a subclass of `FlowExternalOperation`. 
 
 The skeleton `CreateRecurringPaymentLogOperation` is as follows:
 

--- a/content/en/platform/corda/4.7/enterprise/apps/bankinabox/getting-started.md
+++ b/content/en/platform/corda/4.7/enterprise/apps/bankinabox/getting-started.md
@@ -18,7 +18,7 @@ Follow this guide to set up Bank in a Box so you can start testing its features 
 
 ## Prerequisites
 
-Testing the Bank in a Box CorDapp or building your own banking CorDapp both require some Corda programming knowledge. If you are new to Corda, read about [Corda key concepts](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/key-concepts.md) and [CorDapps](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/cordapp-overview.md) to get up to speed.
+Testing the Bank in a Box CorDapp or building your own banking CorDapp both require some Corda programming knowledge. If you are new to Corda, read about [Corda key concepts]({{< relref "../../about-corda/corda-key-concepts.md" >}}) and [CorDapps]({{< relref "../../cordapps/cordapp-overview.md" >}}) to get up to speed.
 
 Follow the general instructions for [Getting set up]({{< relref "../../cordapps/getting-set-up.md" >}}) to develop CorDapps once you are ready to get started with Bank in a Box.
 
@@ -36,7 +36,7 @@ You will also need the following to work on Bank in a Box:
 
 Bank in a Box has the following computational requirements:
 
-* Memory: 6 Gibibytes
+* Memory: 6 Gigabytes
 * CPU: 2000m (2 full cores)
 
 ### Notes on Kubernetes cluster setup

--- a/content/en/platform/corda/4.8/enterprise/apps/bankinabox/back-end-guide.md
+++ b/content/en/platform/corda/4.8/enterprise/apps/bankinabox/back-end-guide.md
@@ -121,7 +121,7 @@ The method checks that the account has sufficient funds - in either the account 
 
 #### Custom serialization
 
-Corda uses the [Kryo serializer](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/serialization-index.md) to serialize objects on the call stack when suspending flows. There are known issues serializing JPA entity objects, particularly if they use one to many relationships or other complex structures. One approach to overcome this is to map entity objects to data classes, referred to as Data Transfer Objects (DTOs), for use within flows. Another approach is to implement custom serializers that generate the serialization for Kryo.
+Corda uses the [Kryo serializer]({{< relref "../../serialization-index.md" >}}) to serialize objects on the call stack when suspending flows. There are known issues serializing JPA entity objects, particularly if they use one to many relationships or other complex structures. One approach to overcome this is to map entity objects to data classes, referred to as Data Transfer Objects (DTOs), for use within flows. Another approach is to implement custom serializers that generate the serialization for Kryo.
 
 A custom serializer for a JPA entity can be specified with the `DefaultSerializer` annotation:
 
@@ -184,7 +184,7 @@ To create a new customer, use the `CreateCustomerFlow`. This flow also adds pers
 * `contactNumber`: Customer phone number.
 * `emailAddress`: Customer email address.
 * `postCode`: Post code of customer's address.
-* `attachments`: List of `SecureHash`, `String` pairs with references to the Corda attachments of additional customer documentation. For more information on the standard process for uploading attachments to Corda, see the documentation on [CorDapp Contract Attachments](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/cordapp-build-systems.md).
+* `attachments`: List of `SecureHash`, `String` pairs with references to the Corda attachments of additional customer documentation. For more information on the standard process for uploading attachments to Corda, see the documentation on [CorDapp Contract Attachments]({{< relref "../../cordapps/cordapp-build-systems.md#cordapp-contract-attachments" >}}).
 
 This flows returns `UUID`, the customer ID.
 
@@ -324,11 +324,11 @@ subFlow(ApproveOverdraftFlow(accountId, amount))
 
 ## Loans
 
-The Bank in a Box application uses [Oracles](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/key-concepts-oracles.md) in various contexts, one of which is in the issuance of loans. A dummy Oracle is used to call external services based on a customer ID and sign off on the loan. The response is then embedded in the transaction that issues the loan. This mimics a real-life scenario where a bank calls a rating provider before giving a customer a loan.
+The Bank in a Box application uses [Oracles]({{< relref "../../key-concepts-oracles.md" >}}) in various contexts, one of which is in the issuance of loans. A dummy Oracle is used to call external services based on a customer ID and sign off on the loan. The response is then embedded in the transaction that issues the loan. This mimics a real-life scenario where a bank calls a rating provider before giving a customer a loan.
 
-Oracle signatures use [partial Merkle tree signing](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/key-concepts-tearoffs.md), which provides privacy for the transaction. In this way, the external party present in the loan issuance transaction can only see the contents of the transaction that they must confirm before signing the transaction.
+Oracle signatures use [partial Merkle tree signing]({{< relref "../../key-concepts-tearoffs.md#merkle-trees-on-corda" >}}), which provides privacy for the transaction. In this way, the external party present in the loan issuance transaction can only see the contents of the transaction that they must confirm before signing the transaction.
 
-When a loan is issued, money is transferred to the customer's current account. In the background, this transaction uses [Corda scheduled states](../../../enterprise/event-scheduling.html#how-to-implement-scheduled-events) to create a recurring payment for that loan, into the loan account.
+When a loan is issued, money is transferred to the customer's current account. In the background, this transaction uses [Corda scheduled states]({{< relref "../../event-scheduling.md#implementing-scheduled-events" >}}) to create a recurring payment for that loan, into the loan account.
 
 ### Business logic
 
@@ -741,7 +741,7 @@ The business logic behind Bank in a Box payments is explained below, addressing:
 
 #### Deduplicating payment logs
 
-In Corda, notaries prevent the double spending of contract states but this naturally excludes off-ledger systems. Instead, Corda provides a <a href="https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/api-flows.md">`FlowExternalOperation`</a> that is executed with a `deduplicationId`, allowing for custom handling of duplicate runs. Each recurring payment execution is logged and duplicate logs can be avoided by creating the payment log instance within a subclass of `FlowExternalOperation`. 
+In Corda, notaries prevent the double spending of contract states but this naturally excludes off-ledger systems. Instead, Corda provides a [FlowExternalOperation]({{< relref "../../cordapps/api-flows.md" >}}) that is executed with a `deduplicationId`, allowing for custom handling of duplicate runs. Each recurring payment execution is logged and duplicate logs can be avoided by creating the payment log instance within a subclass of `FlowExternalOperation`. 
 
 The skeleton `CreateRecurringPaymentLogOperation` is as follows:
 

--- a/content/en/platform/corda/4.8/enterprise/apps/bankinabox/getting-started.md
+++ b/content/en/platform/corda/4.8/enterprise/apps/bankinabox/getting-started.md
@@ -18,9 +18,9 @@ Follow this guide to set up Bank in a Box so you can start testing its features 
 
 ## Prerequisites
 
-Testing the Bank in a Box CorDapp or building your own banking CorDapp both require some Corda programming knowledge. If you are new to Corda, read about [Corda key concepts](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/key-concepts.md) and [CorDapps](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/cordapp-overview.md) to get up to speed.
+Testing the Bank in a Box CorDapp or building your own banking CorDapp both require some Corda programming knowledge. If you are new to Corda, read about [Corda key concepts]({{< relref "../../about-corda/corda-key-concepts.md" >}}) and [CorDapps]({{< relref "../../cordapps/cordapp-overview.md" >}}) to get up to speed.
 
-Follow the general instructions for [Getting set up]({{< relref "../../../../4.10/community/getting-set-up.md" >}}) to develop CorDapps once you are ready to get started with Bank in a Box.
+Follow the general instructions for [Getting set up]({{< relref "../../cordapps/getting-set-up.md" >}}) to develop CorDapps once you are ready to get started with Bank in a Box.
 
 You will also need the following to work on Bank in a Box:
 
@@ -36,7 +36,7 @@ You will also need the following to work on Bank in a Box:
 
 Bank in a Box has the following computational requirements:
 
-* Memory: 6 Gibibytes
+* Memory: 6 Gigabytes
 * CPU: 2000m (2 full cores)
 
 ### Notes on Kubernetes cluster setup
@@ -102,7 +102,7 @@ $ helm repo add bitnami https://charts.bitnami.com/bitnami
 helm install bank-in-a-box-database bitnami/postgresql
 ```
 
-Follow the instructions displayed by the script output to connect to the database server via PSQL. You can create a separate database server for each Bank in a Box service by running the Helm script multiple times with different names and then setting up the database user/schema, following the instructions in the [Corda database setup documentation]({{< relref "../../../enterprise/node-database-intro.md" >}}).
+Follow the instructions displayed by the script output to connect to the database server via PSQL. You can create a separate database server for each Bank in a Box service by running the Helm script multiple times with different names and then setting up the database user/schema, following the instructions in the [Corda database setup documentation]({{< relref "../../node-database-intro.md" >}}).
 Alternatively, you can create several databases inside the single PostgresSQL server you have just deployed, by running the following DDL commands:
 
 ```

--- a/content/en/platform/corda/4.9/community/apps/bankinabox/back-end-guide.md
+++ b/content/en/platform/corda/4.9/community/apps/bankinabox/back-end-guide.md
@@ -326,9 +326,9 @@ subFlow(ApproveOverdraftFlow(accountId, amount))
 
 The Bank in a Box application uses [Oracles]({{< relref "../../key-concepts-oracles.md" >}}) in various contexts, one of which is in the issuance of loans. A dummy Oracle is used to call external services based on a customer ID and sign off on the loan. The response is then embedded in the transaction that issues the loan. This mimics a real-life scenario where a bank calls a rating provider before giving a customer a loan.
 
-Oracle signatures use [partial Merkle tree signing](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/key-concepts-tearoffs.md), which provides privacy for the transaction. In this way, the external party present in the loan issuance transaction can only see the contents of the transaction that they must confirm before signing the transaction.
+Oracle signatures use [partial Merkle tree signing]({{< relref "../../key-concepts-tearoffs.md#merkle-trees-on-corda" >}}), which provides privacy for the transaction. In this way, the external party present in the loan issuance transaction can only see the contents of the transaction that they must confirm before signing the transaction.
 
-When a loan is issued, money is transferred to the customer's current account. In the background, this transaction uses [Corda scheduled states](../../../enterprise/event-scheduling.html#how-to-implement-scheduled-events) to create a recurring payment for that loan, into the loan account.
+When a loan is issued, money is transferred to the customer's current account. In the background, this transaction uses [Corda scheduled states]({{< relref "../../get-started/tutorials/supplementary-tutorials/event-scheduling.md#how-to-implement-scheduled-events" >}}) to create a recurring payment for that loan, into the loan account.
 
 ### Business logic
 
@@ -728,7 +728,7 @@ val signedTx = subFlow(DepositFiatFlow(accountId, amount))
 
 ## Payments
 
-As noted in the [Loans](#loans) section, [Corda scheduled states](../../../enterprise/event-scheduling.html#implementing-scheduled-events) are utilised in Bank in a Box to create recurring payments that start on a given date and are executed in a specific time period.
+As noted in the [Loans](#loans) section, [Corda scheduled states]({{< relref "../../get-started/tutorials/supplementary-tutorials/event-scheduling.md#implementing-scheduled-events" >}}) are utilised in Bank in a Box to create recurring payments that start on a given date and are executed in a specific time period.
 
 Payments in Bank in a Box are also a good example of how CorDapps can be integrated with external systems.
 
@@ -741,7 +741,7 @@ The business logic behind Bank in a Box payments is explained below, addressing:
 
 #### Deduplicating payment logs
 
-In Corda, notaries prevent the double spending of contract states but this naturally excludes off-ledger systems. Instead, Corda provides a <a href="https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/api-flows.md">`FlowExternalOperation`</a> that is executed with a `deduplicationId`, allowing for custom handling of duplicate runs. Each recurring payment execution is logged and duplicate logs can be avoided by creating the payment log instance within a subclass of `FlowExternalOperation`. 
+In Corda, notaries prevent the double spending of contract states but this naturally excludes off-ledger systems. Instead, Corda provides a [FlowExternalOperation]({{< relref "../../api-flows.md" >}}) that is executed with a `deduplicationId`, allowing for custom handling of duplicate runs. Each recurring payment execution is logged and duplicate logs can be avoided by creating the payment log instance within a subclass of `FlowExternalOperation`. 
 
 The skeleton `CreateRecurringPaymentLogOperation` is as follows:
 

--- a/content/en/platform/corda/4.9/community/apps/bankinabox/back-end-guide.md
+++ b/content/en/platform/corda/4.9/community/apps/bankinabox/back-end-guide.md
@@ -121,7 +121,7 @@ The method checks that the account has sufficient funds - in either the account 
 
 #### Custom serialization
 
-Corda uses the [Kryo serializer](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/serialization-index.md) to serialize objects on the call stack when suspending flows. There are known issues serializing JPA entity objects, particularly if they use one to many relationships or other complex structures. One approach to overcome this is to map entity objects to data classes, referred to as Data Transfer Objects (DTOs), for use within flows. Another approach is to implement custom serializers that generate the serialization for Kryo.
+Corda uses the [Kryo serializer]({{< relref "../../serialization-index.md" >}}) to serialize objects on the call stack when suspending flows. There are known issues serializing JPA entity objects, particularly if they use one to many relationships or other complex structures. One approach to overcome this is to map entity objects to data classes, referred to as Data Transfer Objects (DTOs), for use within flows. Another approach is to implement custom serializers that generate the serialization for Kryo.
 
 A custom serializer for a JPA entity can be specified with the `DefaultSerializer` annotation:
 
@@ -184,7 +184,7 @@ To create a new customer, use the `CreateCustomerFlow`. This flow also adds pers
 * `contactNumber`: Customer phone number.
 * `emailAddress`: Customer email address.
 * `postCode`: Post code of customer's address.
-* `attachments`: List of `SecureHash`, `String` pairs with references to the Corda attachments of additional customer documentation. For more information on the standard process for uploading attachments to Corda, see the documentation on [CorDapp Contract Attachments](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/cordapp-build-systems.md).
+* `attachments`: List of `SecureHash`, `String` pairs with references to the Corda attachments of additional customer documentation. For more information on the standard process for uploading attachments to Corda, see the documentation on [CorDapp Contract Attachments]({{< relref "../../cordapp-build-systems.md" >}}).
 
 This flows returns `UUID`, the customer ID.
 
@@ -324,7 +324,7 @@ subFlow(ApproveOverdraftFlow(accountId, amount))
 
 ## Loans
 
-The Bank in a Box application uses [Oracles](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/key-concepts-oracles.md) in various contexts, one of which is in the issuance of loans. A dummy Oracle is used to call external services based on a customer ID and sign off on the loan. The response is then embedded in the transaction that issues the loan. This mimics a real-life scenario where a bank calls a rating provider before giving a customer a loan.
+The Bank in a Box application uses [Oracles]({{< relref "../../key-concepts-oracles.md" >}}) in various contexts, one of which is in the issuance of loans. A dummy Oracle is used to call external services based on a customer ID and sign off on the loan. The response is then embedded in the transaction that issues the loan. This mimics a real-life scenario where a bank calls a rating provider before giving a customer a loan.
 
 Oracle signatures use [partial Merkle tree signing](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/key-concepts-tearoffs.md), which provides privacy for the transaction. In this way, the external party present in the loan issuance transaction can only see the contents of the transaction that they must confirm before signing the transaction.
 

--- a/content/en/platform/corda/4.9/community/apps/bankinabox/getting-started.md
+++ b/content/en/platform/corda/4.9/community/apps/bankinabox/getting-started.md
@@ -18,9 +18,9 @@ Follow this guide to set up Bank in a Box so you can start testing its features 
 
 ## Prerequisites
 
-Testing the Bank in a Box CorDapp or building your own banking CorDapp both require some Corda programming knowledge. If you are new to Corda, read about [Corda key concepts](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/key-concepts.md) and [CorDapps](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/cordapp-overview.md) to get up to speed.
+Testing the Bank in a Box CorDapp or building your own banking CorDapp both require some Corda programming knowledge. If you are new to Corda, read about [Corda key concepts]({{< relref "../../key-concepts.md" >}}) and [CorDapps]({{< relref "../../cordapp-overview.md" >}}) to get up to speed.
 
-Follow the general instructions for [Getting set up]({{< relref "../../../../4.10/community/getting-set-up.md" >}}) to develop CorDapps once you are ready to get started with Bank in a Box.
+Follow the general instructions for [Getting set up]({{< relref "../../getting-set-up.md" >}}) to develop CorDapps once you are ready to get started with Bank in a Box.
 
 You will also need the following to work on Bank in a Box:
 
@@ -171,7 +171,7 @@ BUILD SUCCESSFUL in 6s
 
 ### Set up Docker images
 
-To build your images from source code, `cd` into the root of [the repository cloned above](#clone-the-bank-in-a-box-repository) and execute the following commands to build a Corda node, the credit rating server, web api server, and front-end images:
+To build your images from source code, `cd` into the root of [the repository cloned above](#clone-the-bank-in-a-box-repository) and execute the following commands to build a Corda node, the credit rating server, web API server, and front-end images:
 
 ```
 docker build -t bank-in-a-box:0.0.1 -f docker/corda-node/Dockerfile .

--- a/content/en/platform/corda/4.9/community/apps/bankinabox/getting-started.md
+++ b/content/en/platform/corda/4.9/community/apps/bankinabox/getting-started.md
@@ -36,7 +36,7 @@ You will also need the following to work on Bank in a Box:
 
 Bank in a Box has the following computational requirements:
 
-* Memory: 6 Gibibytes
+* Memory: 6 Gigabytes
 * CPU: 2000m (2 full cores)
 
 ### Notes on Kubernetes cluster setup

--- a/content/en/platform/corda/4.9/community/cordapp-constraint-migration.md
+++ b/content/en/platform/corda/4.9/community/cordapp-constraint-migration.md
@@ -138,12 +138,12 @@ by different parties and it will be expressed as a `CompositeKey` in the `Signat
 to all nodes in that CZ). The CZ network operator should check that the JAR is signed and not allow any more versions of it to be whitelisted in the future.
 From now on the development organisation that signed the JAR is responsible for signing new versions.The process of CZ network CorDapp whitelisting depends on how the Corda network is configured:
 
-* If using a hosted CZ network (such as [The Corda Network](https://docs.corda.net/head/corda-network/index.html) or
-[UAT Environment](https://docs.corda.net/head/corda-network/uat.html) ) running an Identity Operator (formerly known as Doorman) and
+* If using a hosted CZ network (such as [The Corda Network]({{< relref "corda-network/corda-network-foundation.md" >}}) or
+[UAT Environment]({{< relref "corda-network/uat.md" >}})) running an Identity Operator (formerly known as Doorman) and
 Network Map Service, you should manually send the hashes of the two JARs to the CZ network operator and request these be added using
 their network parameter update process.
 * If using a local network created using the Network Bootstrapper tool, please follow the instructions in
-[Updating the contract whitelist for bootstrapped networks](network-bootstrapper.md) to can add both CorDapp Contract JAR hashes.
+[Updating the contract whitelist for bootstrapped networks]({{< relref "network-bootstrapper.md" >}}) to can add both CorDapp Contract JAR hashes.
 * Any flow that builds transactions using this CorDapp will automatically transition states to use the `SignatureAttachmentConstraint` if
 no other constraint is specified and the CorDapp continues to be whitelisted. Therefore, there are two ways to alter the existing code.
   * Do not specify a constraint

--- a/content/en/platform/corda/4.9/community/get-started/get-started-landing.md
+++ b/content/en/platform/corda/4.9/community/get-started/get-started-landing.md
@@ -36,8 +36,8 @@ To start using Corda Community Edition if you have never used Corda before:
 
 If you are already using an open source version of Corda (Corda 4.1–Corda 4.9) and want to upgrade to Corda Community Edition, you can choose to:
 
-* Download the `.tar` [file](https://download.corda.net/corda-community-edition/4.10/community-4.10.tar).
-* Download the `.zip` [file](https://download.corda.net/corda-community-edition/4.10/community-4.10.zip)
+* Download the `.tar` [file](https://download.corda.net/corda-community-edition/4.9/community-4.9.tar).
+* Download the `.zip` [file](https://download.corda.net/corda-community-edition/4.9/community-4.9.zip)
 * Use the Docker image available on [Docker Hub](https://hub.docker.com/repository/docker/corda/community).
 
 Follow the upgrade guides to make sure your [node]({{< relref "../../community/node-upgrade-notes.md" >}}) and [CorDapps]({{< relref "../../community/upgrading-cordapps.md" >}}) are upgraded correctly.

--- a/content/en/platform/corda/4.9/community/get-started/tutorials/overview.md
+++ b/content/en/platform/corda/4.9/community/get-started/tutorials/overview.md
@@ -15,7 +15,7 @@ tags:
 title: Tutorials
 ---
 
-The Corda 4.10 tutorials show you how to build a basic CorDapp and add advanced features to fit your business needs.
+The Corda 4.9 tutorials show you how to build a basic CorDapp and add advanced features to fit your business needs.
 
 Follow the [Building your first CorDapp](build-basic-cordapp/basic-cordapp-intro.md) learning path to learn how to:
 

--- a/content/en/platform/corda/4.9/community/get-started/tutorials/supplementary-tutorials/contract-upgrade.md
+++ b/content/en/platform/corda/4.9/community/get-started/tutorials/supplementary-tutorials/contract-upgrade.md
@@ -71,7 +71,7 @@ class Authorise(
 
 ```
 
-[ContractUpgradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt)
+[ContractUpgradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.9/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt)
 
 ```kotlin
 @StartableByRPC
@@ -81,7 +81,7 @@ class Deauthorise(val stateRef: StateRef) : FlowLogic<Void?>() {
 
 ```
 
-[ContractUpgradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt)
+[ContractUpgradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.9/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt)
 
 
 ## Proposing an upgrade
@@ -160,7 +160,7 @@ class DummyContractV2 : UpgradedContractWithLegacyConstraint<DummyContract.State
 
 ```
 
-[DummyContractV2.kt](https://github.com/corda/corda/blob/release/os/4.8/testing/core-test-utils/src/main/kotlin/net/corda/testing/contracts/DummyContractV2.kt)
+[DummyContractV2.kt](https://github.com/corda/corda/blob/release/os/4.9/testing/core-test-utils/src/main/kotlin/net/corda/testing/contracts/DummyContractV2.kt)
 
 
 * Bank A instructs its node to accept the contract upgrade to `DummyContractV2` for the contract state.

--- a/content/en/platform/corda/4.9/community/get-started/tutorials/supplementary-tutorials/oracles.md
+++ b/content/en/platform/corda/4.9/community/get-started/tutorials/supplementary-tutorials/oracles.md
@@ -18,7 +18,7 @@ title: Writing oracle services
 This tutorial covers *oracles*: network services that link the ledger to the outside world by providing facts that
 affect the validity of transactions.
 
-The [IRS trading demo app](https://github.com/corda/corda/tree/release/os/4.10/samples/irs-demo/cordapp) includes an example oracle that provides an interest rate fixing service.
+The [IRS trading demo app](https://github.com/corda/corda/tree/release/os/4.9/samples/irs-demo/cordapp) includes an example oracle that provides an interest rate fixing service.
 
 ## Introduction
 
@@ -117,7 +117,7 @@ data class FixOf(val name: String, val forDay: LocalDate, val ofTenor: Tenor)
 
 ```
 
-[FinanceTypes.kt](https://github.com/corda/corda/blob/release/os/4.10/finance/contracts/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt)
+[FinanceTypes.kt](https://github.com/corda/corda/blob/release/os/4.9/finance/contracts/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt)
 
 ```kotlin
 /** A [Fix] represents a named interest rate, on a given day, for a given duration. It can be embedded in a tx. */
@@ -125,7 +125,7 @@ data class Fix(val of: FixOf, val value: BigDecimal) : CommandData
 
 ```
 
-[FinanceTypes.kt](https://github.com/corda/corda/blob/release/os/4.10/finance/contracts/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt)
+[FinanceTypes.kt](https://github.com/corda/corda/blob/release/os/4.9/finance/contracts/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt)
 
 ```kotlin
 class Oracle {
@@ -221,7 +221,7 @@ fun sign(ftx: FilteredTransaction): TransactionSignature {
 
 ```
 
-[NodeInterestRates.kt](https://github.com/corda/corda/blob/release/os/4.10/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/api/NodeInterestRates.kt)
+[NodeInterestRates.kt](https://github.com/corda/corda/blob/release/os/4.9/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/api/NodeInterestRates.kt)
 
 Here you can see that there are several steps:
 
@@ -259,7 +259,7 @@ class Oracle(private val services: AppServiceHub) : SingletonSerializeAsToken() 
 
 ```
 
-[NodeInterestRates.kt](https://github.com/corda/corda/blob/release/os/4.10/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/api/NodeInterestRates.kt)
+[NodeInterestRates.kt](https://github.com/corda/corda/blob/release/os/4.9/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/api/NodeInterestRates.kt)
 
 The Corda node scans for any class with this annotation and initialises them. The only requirement is that the class provide
 a constructor with a single parameter of type `ServiceHub`.
@@ -295,7 +295,7 @@ class FixQueryHandler(private val otherPartySession: FlowSession) : FlowLogic<Un
 
 ```
 
-[NodeInterestRates.kt](https://github.com/corda/corda/blob/release/os/4.10/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/api/NodeInterestRates.kt)
+[NodeInterestRates.kt](https://github.com/corda/corda/blob/release/os/4.9/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/api/NodeInterestRates.kt)
 
 These two flows leverage the oracle to provide the querying and signing operations. They get reference to the oracle,
 which will have already been initialised by the node, using `ServiceHub.cordaService`. Both flows are annotated with
@@ -344,7 +344,7 @@ class FixSignFlow(val tx: TransactionBuilder, val oracle: Party,
 
 ```
 
-[RatesFixFlow.kt](https://github.com/corda/corda/blob/release/os/4.10/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/flows/RatesFixFlow.kt)
+[RatesFixFlow.kt](https://github.com/corda/corda/blob/release/os/4.9/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/flows/RatesFixFlow.kt)
 
 You’ll note that the `FixSignFlow` requires a `FilterTransaction` instance which includes only `Fix` commands.
 You can find a further explanation of this in [Oracles]({{< relref "../../../key-concepts-oracles.md" >}}). Below you will see how to build such a
@@ -373,7 +373,7 @@ override fun call(): TransactionSignature {
 
 ```
 
-[RatesFixFlow.kt](https://github.com/corda/corda/blob/release/os/4.10/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/flows/RatesFixFlow.kt)
+[RatesFixFlow.kt](https://github.com/corda/corda/blob/release/os/4.9/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/flows/RatesFixFlow.kt)
 
 As you can see, this:
 
@@ -412,7 +412,7 @@ Here’s an example of it in action from `FixingFlow.Fixer`.
 
 ```
 
-[FixingFlow.kt](https://github.com/corda/corda/blob/release/os/4.10/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/flows/FixingFlow.kt)
+[FixingFlow.kt](https://github.com/corda/corda/blob/release/os/4.9/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/flows/FixingFlow.kt)
 
 {{< note >}}
 When overriding be careful when making the sub-class an anonymous or inner class (object declarations in Kotlin),
@@ -458,4 +458,4 @@ You can then write tests on your mock network to verify the nodes interact with 
 
 ```
 
-For more examples, see [OracleNodeTearOffTests.kt](https://github.com/corda/corda/tree/release/os/4.10/samples/irs-demo/cordapp/workflows-irs/src/test/kotlin/net/corda/irs/api/OracleNodeTearOffTests.kt).
+For more examples, see [OracleNodeTearOffTests.kt](https://github.com/corda/corda/tree/release/os/4.9/samples/irs-demo/cordapp/workflows-irs/src/test/kotlin/net/corda/irs/api/OracleNodeTearOffTests.kt).

--- a/content/en/platform/corda/4.9/community/get-started/tutorials/supplementary-tutorials/tutorial-clientrpc-api.md
+++ b/content/en/platform/corda/4.9/community/get-started/tutorials/supplementary-tutorials/tutorial-clientrpc-api.md
@@ -427,7 +427,7 @@ thread {
     fun isWaitingForShutdown(): Boolean
 ```
 
-[CordaRPCOps.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt)
+[CordaRPCOps.kt](https://github.com/corda/corda/blob/release/os/4.9/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt)
 
 ## Creating the transaction graph
 

--- a/content/en/platform/corda/4.9/community/get-started/tutorials/supplementary-tutorials/tutorial-custom-notary.md
+++ b/content/en/platform/corda/4.9/community/get-started/tutorials/supplementary-tutorials/tutorial-custom-notary.md
@@ -48,7 +48,7 @@ class MyCustomValidatingNotaryService(
 
 ```
 
-[MyCustomNotaryService.kt](https://github.com/corda/corda/blob/release/os/4.10/samples/notary-demo/workflows/src/main/kotlin/net/corda/notarydemo/MyCustomNotaryService.kt)
+[MyCustomNotaryService.kt](https://github.com/corda/corda/blob/release/os/4.9/samples/notary-demo/workflows/src/main/kotlin/net/corda/notarydemo/MyCustomNotaryService.kt)
 
 ## Writing a flow for the custom notary service
 
@@ -91,7 +91,7 @@ class MyValidatingNotaryFlow(otherSide: FlowSession, service: MyCustomValidating
 
 ```
 
-[MyCustomNotaryService.kt](https://github.com/corda/corda/blob/release/os/4.10/samples/notary-demo/workflows/src/main/kotlin/net/corda/notarydemo/MyCustomNotaryService.kt)
+[MyCustomNotaryService.kt](https://github.com/corda/corda/blob/release/os/4.9/samples/notary-demo/workflows/src/main/kotlin/net/corda/notarydemo/MyCustomNotaryService.kt)
 
 ## Updating the node configuration
 
@@ -121,6 +121,6 @@ To create a flow test that uses your custom notary service, you can set the clas
 
 ```
 
-[CustomNotaryTest.kt](https://github.com/corda/corda/blob/release/os/4.10/testing/node-driver/src/test/kotlin/net/corda/testing/node/CustomNotaryTest.kt)
+[CustomNotaryTest.kt](https://github.com/corda/corda/blob/release/os/4.9/testing/node-driver/src/test/kotlin/net/corda/testing/node/CustomNotaryTest.kt)
 
 After this, your custom notary will be the default notary on the mock network, and can be used in the same way as described in [Write integration tests]({{< relref "../build-basic-cordapp/basic-cordapp-unit-testing.md" >}}).

--- a/content/en/platform/corda/4.9/community/get-started/tutorials/supplementary-tutorials/tutorial-tear-offs.md
+++ b/content/en/platform/corda/4.9/community/get-started/tutorials/supplementary-tutorials/tutorial-tear-offs.md
@@ -118,7 +118,7 @@ fun sign(ftx: FilteredTransaction): TransactionSignature {
 
 ```
 
-[NodeInterestRates.kt](https://github.com/corda/corda/blob/release/os/4.10/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/api/NodeInterestRates.kt)
+[NodeInterestRates.kt](https://github.com/corda/corda/blob/release/os/4.9/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/api/NodeInterestRates.kt)
 
 {{< note >}}
 The way the `FilteredTransaction` is constructed ensures that after signing of the root hash, it is impossible to add or remove

--- a/content/en/platform/corda/4.9/enterprise/apps/bankinabox/back-end-guide.md
+++ b/content/en/platform/corda/4.9/enterprise/apps/bankinabox/back-end-guide.md
@@ -121,7 +121,7 @@ The method checks that the account has sufficient funds - in either the account 
 
 #### Custom serialization
 
-Corda uses the [Kryo serializer](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/serialization-index.md) to serialize objects on the call stack when suspending flows. There are known issues serializing JPA entity objects, particularly if they use one to many relationships or other complex structures. One approach to overcome this is to map entity objects to data classes, referred to as Data Transfer Objects (DTOs), for use within flows. Another approach is to implement custom serializers that generate the serialization for Kryo.
+Corda uses the [Kryo serializer]({{< relref "../../serialization-index.md" >}}) to serialize objects on the call stack when suspending flows. There are known issues serializing JPA entity objects, particularly if they use one to many relationships or other complex structures. One approach to overcome this is to map entity objects to data classes, referred to as Data Transfer Objects (DTOs), for use within flows. Another approach is to implement custom serializers that generate the serialization for Kryo.
 
 A custom serializer for a JPA entity can be specified with the `DefaultSerializer` annotation:
 
@@ -184,7 +184,7 @@ To create a new customer, use the `CreateCustomerFlow`. This flow also adds pers
 * `contactNumber`: Customer phone number.
 * `emailAddress`: Customer email address.
 * `postCode`: Post code of customer's address.
-* `attachments`: List of `SecureHash`, `String` pairs with references to the Corda attachments of additional customer documentation. For more information on the standard process for uploading attachments to Corda, see the documentation on [CorDapp Contract Attachments](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/cordapp-build-systems.md).
+* `attachments`: List of `SecureHash`, `String` pairs with references to the Corda attachments of additional customer documentation. For more information on the standard process for uploading attachments to Corda, see the documentation on [CorDapp Contract Attachments]({{< relref "../../cordapps/cordapp-build-systems.md" >}}).
 
 This flows returns `UUID`, the customer ID.
 
@@ -324,11 +324,11 @@ subFlow(ApproveOverdraftFlow(accountId, amount))
 
 ## Loans
 
-The Bank in a Box application uses [Oracles](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/key-concepts-oracles.md) in various contexts, one of which is in the issuance of loans. A dummy Oracle is used to call external services based on a customer ID and sign off on the loan. The response is then embedded in the transaction that issues the loan. This mimics a real-life scenario where a bank calls a rating provider before giving a customer a loan.
+The Bank in a Box application uses [Oracles]({{< relref "../../key-concepts-oracles.md" >}}) in various contexts, one of which is in the issuance of loans. A dummy Oracle is used to call external services based on a customer ID and sign off on the loan. The response is then embedded in the transaction that issues the loan. This mimics a real-life scenario where a bank calls a rating provider before giving a customer a loan.
 
-Oracle signatures use [partial Merkle tree signing](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/key-concepts-tearoffs.md), which provides privacy for the transaction. In this way, the external party present in the loan issuance transaction can only see the contents of the transaction that they must confirm before signing the transaction.
+Oracle signatures use [partial Merkle tree signing]({{< relref "../../key-concepts-tearoffs.md#merkle-trees-on-corda" >}}), which provides privacy for the transaction. In this way, the external party present in the loan issuance transaction can only see the contents of the transaction that they must confirm before signing the transaction.
 
-When a loan is issued, money is transferred to the customer's current account. In the background, this transaction uses [Corda scheduled states](../../../enterprise/event-scheduling.html#how-to-implement-scheduled-events) to create a recurring payment for that loan, into the loan account.
+When a loan is issued, money is transferred to the customer's current account. In the background, this transaction uses [Corda scheduled states]({{< relref "../../../enterprise/event-scheduling.md#how-to-implement-scheduled-events" >}}) to create a recurring payment for that loan, into the loan account.
 
 ### Business logic
 
@@ -741,7 +741,7 @@ The business logic behind Bank in a Box payments is explained below, addressing:
 
 #### Deduplicating payment logs
 
-In Corda, notaries prevent the double spending of contract states but this naturally excludes off-ledger systems. Instead, Corda provides a <a href="https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/api-flows.md">`FlowExternalOperation`</a> that is executed with a `deduplicationId`, allowing for custom handling of duplicate runs. Each recurring payment execution is logged and duplicate logs can be avoided by creating the payment log instance within a subclass of `FlowExternalOperation`. 
+In Corda, notaries prevent the double spending of contract states but this naturally excludes off-ledger systems. Instead, Corda provides a [FlowExternalOperation]({{< relref "../../cordapps/api-flows.md" >}}) that is executed with a `deduplicationId`, allowing for custom handling of duplicate runs. Each recurring payment execution is logged and duplicate logs can be avoided by creating the payment log instance within a subclass of `FlowExternalOperation`. 
 
 The skeleton `CreateRecurringPaymentLogOperation` is as follows:
 

--- a/content/en/platform/corda/4.9/enterprise/apps/bankinabox/back-end-guide.md
+++ b/content/en/platform/corda/4.9/enterprise/apps/bankinabox/back-end-guide.md
@@ -121,7 +121,7 @@ The method checks that the account has sufficient funds - in either the account 
 
 #### Custom serialization
 
-Corda uses the [Kryo serializer](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/serialization-index.md) to serialize objects on the call stack when suspending flows. There are known issues serializing JPA entity objects, particularly if they use one to many relationships or other complex structures. One approach to overcome this is to map entity objects to data classes, referred to as Data Transfer Objects (DTOs), for use within flows. Another approach is to implement custom serializers that generate the serialization for Kryo.
+Corda uses the [Kryo serializer](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/serialization-index.md) to serialize objects on the call stack when suspending flows. There are known issues serializing JPA entity objects, particularly if they use one to many relationships or other complex structures. One approach to overcome this is to map entity objects to data classes, referred to as Data Transfer Objects (DTOs), for use within flows. Another approach is to implement custom serializers that generate the serialization for Kryo.
 
 A custom serializer for a JPA entity can be specified with the `DefaultSerializer` annotation:
 
@@ -184,7 +184,7 @@ To create a new customer, use the `CreateCustomerFlow`. This flow also adds pers
 * `contactNumber`: Customer phone number.
 * `emailAddress`: Customer email address.
 * `postCode`: Post code of customer's address.
-* `attachments`: List of `SecureHash`, `String` pairs with references to the Corda attachments of additional customer documentation. For more information on the standard process for uploading attachments to Corda, see the documentation on [CorDapp Contract Attachments](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/cordapp-build-systems.md).
+* `attachments`: List of `SecureHash`, `String` pairs with references to the Corda attachments of additional customer documentation. For more information on the standard process for uploading attachments to Corda, see the documentation on [CorDapp Contract Attachments](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/cordapp-build-systems.md).
 
 This flows returns `UUID`, the customer ID.
 
@@ -324,9 +324,9 @@ subFlow(ApproveOverdraftFlow(accountId, amount))
 
 ## Loans
 
-The Bank in a Box application uses [Oracles](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/key-concepts-oracles.md) in various contexts, one of which is in the issuance of loans. A dummy Oracle is used to call external services based on a customer ID and sign off on the loan. The response is then embedded in the transaction that issues the loan. This mimics a real-life scenario where a bank calls a rating provider before giving a customer a loan.
+The Bank in a Box application uses [Oracles](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/key-concepts-oracles.md) in various contexts, one of which is in the issuance of loans. A dummy Oracle is used to call external services based on a customer ID and sign off on the loan. The response is then embedded in the transaction that issues the loan. This mimics a real-life scenario where a bank calls a rating provider before giving a customer a loan.
 
-Oracle signatures use [partial Merkle tree signing](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/key-concepts-tearoffs.md), which provides privacy for the transaction. In this way, the external party present in the loan issuance transaction can only see the contents of the transaction that they must confirm before signing the transaction.
+Oracle signatures use [partial Merkle tree signing](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/key-concepts-tearoffs.md), which provides privacy for the transaction. In this way, the external party present in the loan issuance transaction can only see the contents of the transaction that they must confirm before signing the transaction.
 
 When a loan is issued, money is transferred to the customer's current account. In the background, this transaction uses [Corda scheduled states](../../../enterprise/event-scheduling.html#how-to-implement-scheduled-events) to create a recurring payment for that loan, into the loan account.
 
@@ -741,7 +741,7 @@ The business logic behind Bank in a Box payments is explained below, addressing:
 
 #### Deduplicating payment logs
 
-In Corda, notaries prevent the double spending of contract states but this naturally excludes off-ledger systems. Instead, Corda provides a <a href="https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/api-flows.md">`FlowExternalOperation`</a> that is executed with a `deduplicationId`, allowing for custom handling of duplicate runs. Each recurring payment execution is logged and duplicate logs can be avoided by creating the payment log instance within a subclass of `FlowExternalOperation`. 
+In Corda, notaries prevent the double spending of contract states but this naturally excludes off-ledger systems. Instead, Corda provides a <a href="https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.10/api-flows.md">`FlowExternalOperation`</a> that is executed with a `deduplicationId`, allowing for custom handling of duplicate runs. Each recurring payment execution is logged and duplicate logs can be avoided by creating the payment log instance within a subclass of `FlowExternalOperation`. 
 
 The skeleton `CreateRecurringPaymentLogOperation` is as follows:
 

--- a/content/en/platform/corda/4.9/enterprise/apps/bankinabox/getting-started.md
+++ b/content/en/platform/corda/4.9/enterprise/apps/bankinabox/getting-started.md
@@ -18,7 +18,7 @@ Follow this guide to set up Bank in a Box so you can start testing its features 
 
 ## Prerequisites
 
-Testing the Bank in a Box CorDapp or building your own banking CorDapp both require some Corda programming knowledge. If you are new to Corda, read about [Corda key concepts](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/key-concepts.md) and [CorDapps](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/corda-os/4.7/cordapp-overview.md) to get up to speed.
+Testing the Bank in a Box CorDapp or building your own banking CorDapp both require some Corda programming knowledge. If you are new to Corda, read about [Corda key concepts]({{< relref "../../about-corda/corda-key-concepts.md" >}}) and [CorDapps]({{< relref "../../cordapps/cordapp-overview.md" >}}) to get up to speed.
 
 Follow the general instructions for [Getting set up]({{< relref "../../cordapps/getting-set-up.md" >}}) to develop CorDapps once you are ready to get started with Bank in a Box.
 
@@ -149,7 +149,7 @@ The following projects must be built to run Bank in a Box:
 - `webservices`
 
 
-To build your JAR files from source code, `cd` into the root of [the repository cloned above](#clone-the-bank-in-a-box-repository) and execute the following commands:
+To build your JAR files from source code, `cd` into the root of [the repository cloned above]({{< relref "#clone-the-bank-in-a-box-repository" >}}) and execute the following commands:
 
 `./gradlew workflows:jar`
 
@@ -171,7 +171,7 @@ BUILD SUCCESSFUL in 6s
 
 ### Set up Docker images
 
-To build your images from source code, `cd` into the root of [the repository cloned above](#clone-the-bank-in-a-box-repository) and execute the following commands to build a Corda node, the credit rating server, web api server, and front-end images:
+To build your images from source code, `cd` into the root of [the repository cloned above]({{< relref "#clone-the-bank-in-a-box-repository" >}}) and execute the following commands to build a Corda node, the credit rating server, web api server, and front-end images:
 
 ```
 docker build -t bank-in-a-box:0.0.1 -f docker/corda-node/Dockerfile .
@@ -209,7 +209,7 @@ front-end                                   0.0.1                               
 
 ### `helm install`
 
-To install Bank in a Box services to the Kubernetes cluster, use the `helm install` command. The installation command must be triggered from the `helm` directory of the [the repository cloned above](#clone-the-bank-in-a-box-repository).
+To install Bank in a Box services to the Kubernetes cluster, use the `helm install` command. The installation command must be triggered from the `helm` directory of the [the repository cloned above]({{< relref "#clone-the-bank-in-a-box-repository" >}}).
 
 1. Navigate to the `helm` directory.
 ```

--- a/content/en/platform/corda/4.9/enterprise/apps/bankinabox/getting-started.md
+++ b/content/en/platform/corda/4.9/enterprise/apps/bankinabox/getting-started.md
@@ -36,7 +36,7 @@ You will also need the following to work on Bank in a Box:
 
 Bank in a Box has the following computational requirements:
 
-* Memory: 6 Gibibytes
+* Memory: 6 Gigabytes
 * CPU: 2000m (2 full cores)
 
 ### Notes on Kubernetes cluster setup

--- a/content/en/platform/corda/4.9/enterprise/contract-upgrade.md
+++ b/content/en/platform/corda/4.9/enterprise/contract-upgrade.md
@@ -61,7 +61,7 @@ class Authorise(
 
 ```
 
-[ContractUpgradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt)
+[ContractUpgradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.9/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt)
 
 ```kotlin
 @StartableByRPC
@@ -71,7 +71,7 @@ class Deauthorise(val stateRef: StateRef) : FlowLogic<Void?>() {
 
 ```
 
-[ContractUpgradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.8/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt)
+[ContractUpgradeFlow.kt](https://github.com/corda/corda/blob/release/os/4.9/core/src/main/kotlin/net/corda/core/flows/ContractUpgradeFlow.kt)
 
 
 ## Proposing an upgrade
@@ -150,7 +150,7 @@ class DummyContractV2 : UpgradedContractWithLegacyConstraint<DummyContract.State
 
 ```
 
-[DummyContractV2.kt](https://github.com/corda/corda/blob/release/os/4.4/testing/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyContractV2.kt)
+[DummyContractV2.kt](https://github.com/corda/corda/blob/release/os/4.9/testing/test-utils/src/main/kotlin/net/corda/testing/contracts/DummyContractV2.kt)
 
 
 Bank A instructs its node to accept the contract upgrade to `DummyContractV2` for the contract state.

--- a/content/en/platform/corda/4.9/enterprise/get-started/getting-started-with-corda-4.md
+++ b/content/en/platform/corda/4.9/enterprise/get-started/getting-started-with-corda-4.md
@@ -22,7 +22,7 @@ The best way to get started with Corda is to:
      If you are new to Corda and would like to experience Corda Enterprise, you can [register for a trial now](https://www.corda.net/get-corda/).
    * **Corda Community Edition** - the open source version of Corda, which you can build on now. To use Corda Community Edition, you can access the latest version in one of three ways:
      * Clone the [Github repository](https://github.com/corda/corda), then follow the tutorials to set up your nodes and developer environment.
-     * Download the latest Corda Community Edition `.tar` [file](https://download.corda.net/corda-community-edition/4.10/community-4.10.tar) that contains the required Corda `.jars`. 
+     * Download the latest Corda Community Edition `.tar` [file](https://download.corda.net/corda-community-edition/4.9/community-4.9.tar) that contains the required Corda `.jars`. 
      * Use the Docker image and accompanying guide from the [Docker Hub](https://hub.docker.com/repository/docker/corda/community).
 
 2. Familiarize yourself with the [Corda key concepts]({{< relref "../../enterprise/about-corda/corda-key-concepts.md" >}}). 

--- a/content/en/platform/corda/4.9/enterprise/get-started/tutorials/overview.md
+++ b/content/en/platform/corda/4.9/enterprise/get-started/tutorials/overview.md
@@ -11,7 +11,7 @@ tags:
 title: Tutorials
 ---
 
-The Corda 4.10 tutorials show you how to build a basic CorDapp and add advanced features to fit your business needs.
+The Corda 4.9 tutorials show you how to build a basic CorDapp and add advanced features to fit your business needs.
 
 Follow the [Building your first CorDapp](build-basic-cordapp/basic-cordapp-intro.md) learning path to learn how to:
 

--- a/content/en/platform/corda/4.9/enterprise/get-started/tutorials/supplementary-tutorials/oracles.md
+++ b/content/en/platform/corda/4.9/enterprise/get-started/tutorials/supplementary-tutorials/oracles.md
@@ -18,7 +18,7 @@ title: Writing oracle services
 This tutorial covers *oracles*: network services that link the ledger to the outside world by providing facts that
 affect the validity of transactions.
 
-The [IRS trading demo app](https://github.com/corda/corda/tree/release/os/4.10/samples/irs-demo/cordapp) includes an example oracle that provides an interest rate fixing service.
+The [IRS trading demo app](https://github.com/corda/corda/tree/release/os/4.9/samples/irs-demo/cordapp) includes an example oracle that provides an interest rate fixing service.
 
 ## Introduction
 
@@ -117,7 +117,7 @@ data class FixOf(val name: String, val forDay: LocalDate, val ofTenor: Tenor)
 
 ```
 
-[FinanceTypes.kt](https://github.com/corda/corda/blob/release/os/4.10/finance/contracts/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt)
+[FinanceTypes.kt](https://github.com/corda/corda/blob/release/os/4.9/finance/contracts/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt)
 
 ```kotlin
 /** A [Fix] represents a named interest rate, on a given day, for a given duration. It can be embedded in a tx. */
@@ -125,7 +125,7 @@ data class Fix(val of: FixOf, val value: BigDecimal) : CommandData
 
 ```
 
-[FinanceTypes.kt](https://github.com/corda/corda/blob/release/os/4.10/finance/contracts/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt)
+[FinanceTypes.kt](https://github.com/corda/corda/blob/release/os/4.9/finance/contracts/src/main/kotlin/net/corda/finance/contracts/FinanceTypes.kt)
 
 ```kotlin
 class Oracle {
@@ -221,7 +221,7 @@ fun sign(ftx: FilteredTransaction): TransactionSignature {
 
 ```
 
-[NodeInterestRates.kt](https://github.com/corda/corda/blob/release/os/4.10/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/api/NodeInterestRates.kt)
+[NodeInterestRates.kt](https://github.com/corda/corda/blob/release/os/4.9/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/api/NodeInterestRates.kt)
 
 Here you can see that there are several steps:
 
@@ -259,7 +259,7 @@ class Oracle(private val services: AppServiceHub) : SingletonSerializeAsToken() 
 
 ```
 
-[NodeInterestRates.kt](https://github.com/corda/corda/blob/release/os/4.10/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/api/NodeInterestRates.kt)
+[NodeInterestRates.kt](https://github.com/corda/corda/blob/release/os/4.9/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/api/NodeInterestRates.kt)
 
 The Corda node scans for any class with this annotation and initialises them. The only requirement is that the class provide
 a constructor with a single parameter of type `ServiceHub`.
@@ -295,7 +295,7 @@ class FixQueryHandler(private val otherPartySession: FlowSession) : FlowLogic<Un
 
 ```
 
-[NodeInterestRates.kt](https://github.com/corda/corda/blob/release/os/4.10/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/api/NodeInterestRates.kt)
+[NodeInterestRates.kt](https://github.com/corda/corda/blob/release/os/4.9/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/api/NodeInterestRates.kt)
 
 These two flows leverage the oracle to provide the querying and signing operations. They get reference to the oracle,
 which will have already been initialised by the node, using `ServiceHub.cordaService`. Both flows are annotated with
@@ -344,7 +344,7 @@ class FixSignFlow(val tx: TransactionBuilder, val oracle: Party,
 
 ```
 
-[RatesFixFlow.kt](https://github.com/corda/corda/blob/release/os/4.10/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/flows/RatesFixFlow.kt)
+[RatesFixFlow.kt](https://github.com/corda/corda/blob/release/os/4.9/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/flows/RatesFixFlow.kt)
 
 You’ll note that the `FixSignFlow` requires a `FilterTransaction` instance which includes only `Fix` commands.
 You can find a further explanation of this in [Oracles]({{< relref "../../../key-concepts-oracles.md" >}}). Below you will see how to build such a
@@ -373,7 +373,7 @@ override fun call(): TransactionSignature {
 
 ```
 
-[RatesFixFlow.kt](https://github.com/corda/corda/blob/release/os/4.10/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/flows/RatesFixFlow.kt)
+[RatesFixFlow.kt](https://github.com/corda/corda/blob/release/os/4.9/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/flows/RatesFixFlow.kt)
 
 As you can see, this:
 
@@ -412,7 +412,7 @@ Here’s an example of it in action from `FixingFlow.Fixer`.
 
 ```
 
-[FixingFlow.kt](https://github.com/corda/corda/blob/release/os/4.10/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/flows/FixingFlow.kt)
+[FixingFlow.kt](https://github.com/corda/corda/blob/release/os/4.9/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/flows/FixingFlow.kt)
 
 {{< note >}}
 When overriding be careful when making the sub-class an anonymous or inner class (object declarations in Kotlin),
@@ -458,4 +458,4 @@ You can then write tests on your mock network to verify the nodes interact with 
 
 ```
 
-For more examples, see [OracleNodeTearOffTests.kt](https://github.com/corda/corda/tree/release/os/4.10/samples/irs-demo/cordapp/workflows-irs/src/test/kotlin/net/corda/irs/api/OracleNodeTearOffTests.kt).
+For more examples, see [OracleNodeTearOffTests.kt](https://github.com/corda/corda/tree/release/os/4.9/samples/irs-demo/cordapp/workflows-irs/src/test/kotlin/net/corda/irs/api/OracleNodeTearOffTests.kt).

--- a/content/en/platform/corda/4.9/enterprise/get-started/tutorials/supplementary-tutorials/tutorial-clientrpc-api.md
+++ b/content/en/platform/corda/4.9/enterprise/get-started/tutorials/supplementary-tutorials/tutorial-clientrpc-api.md
@@ -427,7 +427,7 @@ thread {
     fun isWaitingForShutdown(): Boolean
 ```
 
-[CordaRPCOps.kt](https://github.com/corda/corda/blob/release/os/4.10/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt)
+[CordaRPCOps.kt](https://github.com/corda/corda/blob/release/os/4.9/core/src/main/kotlin/net/corda/core/messaging/CordaRPCOps.kt)
 
 ## Creating the transaction graph
 

--- a/content/en/platform/corda/4.9/enterprise/get-started/tutorials/supplementary-tutorials/tutorial-custom-notary.md
+++ b/content/en/platform/corda/4.9/enterprise/get-started/tutorials/supplementary-tutorials/tutorial-custom-notary.md
@@ -48,7 +48,7 @@ class MyCustomValidatingNotaryService(
 
 ```
 
-[MyCustomNotaryService.kt](https://github.com/corda/corda/blob/release/os/4.10/samples/notary-demo/workflows/src/main/kotlin/net/corda/notarydemo/MyCustomNotaryService.kt)
+[MyCustomNotaryService.kt](https://github.com/corda/corda/blob/release/os/4.9/samples/notary-demo/workflows/src/main/kotlin/net/corda/notarydemo/MyCustomNotaryService.kt)
 
 ## Writing a flow for the custom notary service
 
@@ -91,7 +91,7 @@ class MyValidatingNotaryFlow(otherSide: FlowSession, service: MyCustomValidating
 
 ```
 
-[MyCustomNotaryService.kt](https://github.com/corda/corda/blob/release/os/4.10/samples/notary-demo/workflows/src/main/kotlin/net/corda/notarydemo/MyCustomNotaryService.kt)
+[MyCustomNotaryService.kt](https://github.com/corda/corda/blob/release/os/4.9/samples/notary-demo/workflows/src/main/kotlin/net/corda/notarydemo/MyCustomNotaryService.kt)
 
 ## Updating the node configuration
 
@@ -121,6 +121,6 @@ To create a flow test that uses your custom notary service, you can set the clas
 
 ```
 
-[CustomNotaryTest.kt](https://github.com/corda/corda/blob/release/os/4.10/testing/node-driver/src/test/kotlin/net/corda/testing/node/CustomNotaryTest.kt)
+[CustomNotaryTest.kt](https://github.com/corda/corda/blob/release/os/4.9/testing/node-driver/src/test/kotlin/net/corda/testing/node/CustomNotaryTest.kt)
 
 After this, your custom notary will be the default notary on the mock network, and can be used in the same way as described in [Write integration tests]({{< relref "../build-basic-cordapp/basic-cordapp-unit-testing.md" >}}).

--- a/content/en/platform/corda/4.9/enterprise/get-started/tutorials/supplementary-tutorials/tutorial-tear-offs.md
+++ b/content/en/platform/corda/4.9/enterprise/get-started/tutorials/supplementary-tutorials/tutorial-tear-offs.md
@@ -118,7 +118,7 @@ fun sign(ftx: FilteredTransaction): TransactionSignature {
 
 ```
 
-[NodeInterestRates.kt](https://github.com/corda/corda/blob/release/os/4.10/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/api/NodeInterestRates.kt)
+[NodeInterestRates.kt](https://github.com/corda/corda/blob/release/os/4.9/samples/irs-demo/cordapp/workflows-irs/src/main/kotlin/net.corda.irs/api/NodeInterestRates.kt)
 
 {{< note >}}
 The way the `FilteredTransaction` is constructed ensures that after signing of the root hash, it is impossible to add or remove

--- a/content/en/platform/corda/4.9/enterprise/node/operating/node-administration.md
+++ b/content/en/platform/corda/4.9/enterprise/node/operating/node-administration.md
@@ -18,7 +18,7 @@ weight: 145
 ## Logging
 
 Corda's logging feature uses a [Log4j 2](https://logging.apache.org/log4j/2.x/) component and an [SLF4J ](https://www.slf4j.org/interface)
-interface as its abstraction layer. You can find the latest Corda logging configuration file on [GitHub](https://github.com/corda/corda/blob/release/os/4.10/config/dev/log4j2.xml).
+interface as its abstraction layer. You can find the latest Corda logging configuration file on [GitHub](https://github.com/corda/corda/blob/release/os/4.9/config/dev/log4j2.xml).
 
 * By default, node log files are stored to the `logs` subdirectory of the working directory and are rotated from time to time.
 * Passing the `--log-to-console` command line flag logs printing to the console.


### PR DESCRIPTION
This includes fixing wrong versions in text and in links. Also fixed links where it was pointing to an old version of a topic in the archived docs, where that topic actually exists in the same version of the current docs.