### PR TITLE
Add hyperlinks to glossary terms

### DIFF
--- a/themes/doks/layouts/shortcodes/glossary.html
+++ b/themes/doks/layouts/shortcodes/glossary.html
@@ -5,9 +5,11 @@
 {{ $glossarylist := getJSON "content/en/platform/corda/5.0/glossaryitems.json" }}
 
     {{ range $term, $value := $glossarylist }}
+        {{ $termkebab := lower (replace $term " " "-") }}
+
         {{ with $value.more }}
-            <details><summary ><b>{{ $term }}</b><br>{{ $value.definition }}</summary>{{ safeHTML $value.more }}</details>
+           <details><summary><h4 id="{{ $termkebab }}">{{ $term }}</h4>{{ $value.definition }}</summary>{{ safeHTML $value.more }}</details>
         {{ else }}
-            <p style="margin-top: 1rem";><b>{{ $term }}</b><br>{{ $value.definition }}</p>
+            <p style="margin-top: 1rem";><h4>{{ $term }}</h4>{{ $value.definition }}</p>
         {{ end }}
     {{ end }}

--- a/themes/doks/layouts/shortcodes/tooltip.html
+++ b/themes/doks/layouts/shortcodes/tooltip.html
@@ -1,5 +1,5 @@
 {{/* Function to display the definition for the specified term, as defined for Corda 5 in glossaryitems.json, as a tooltip.*/}}
-{{/* Example usage: {{< tooltip >}}CorDapp{{< /tooltip >}}*/}}
+{{/* Example usage: {{< tooltip >}}CorDapp{{< /tooltip >}} */}}
 {{/* NOTE the "term" passed to this shortcode is case-insensitive and simple plural versions should match. For example, passing "members" should match "Member" in the JSON file. */}}
 
 <style>
@@ -28,19 +28,29 @@
         visibility: visible;
         opacity: 1;
     }
+
+    .term .definition::after {
+    content: " ";
+    position: absolute;
+    top: 100%; /* At the bottom of the tooltip */
+    left: 50%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: #555 transparent transparent transparent;
+    }    
+
 </style>
 
 <span class="term">&nbsp{{ .Inner }}
     {{ $searchtermlower := lower .Inner }}
     {{ $glossarylist := getJSON "content/en/platform/corda/5.0/glossaryitems.json" }}
-
-        {{ range $term, $value := $glossarylist }}
-            {{ $term := lower $term }}
-            {{ if eq $term $searchtermlower }} 
-                <span class="definition">{{ $value.definition }}</span>
-            {{ else if eq $term (strings.TrimSuffix "s" $searchtermlower) }}
-                <span class="definition">{{ $value.definition }}</span>
-            {{ end }}
+    {{ range $term, $value := $glossarylist }}
+        {{ $term := lower $term }}
+        {{ if eq $term $searchtermlower }} 
+               <span class="definition">{{ $value.definition }}</span>
+        {{ else if eq $term (strings.TrimSuffix "s" $searchtermlower) }}
+               <span class="definition">{{ $value.definition }}</span>
         {{ end }}
-
+    {{ end }}
 </span>


### PR DESCRIPTION
- Add an arrow to glossary tooltips
![image](https://github.com/corda/corda-docs-portal/assets/103633799/aa30c9ac-bc00-44a0-ac4f-86625232ecca)
![image](https://github.com/corda/corda-docs-portal/assets/103633799/5bf785f2-bd1e-40fd-8779-2fd75fa57ec4)
- Add an HTML `id` to the terms in the full glossary list so we can link to them.

Preview here: https://nadine.preview.docs.r3.com/en/platform/corda/5.0.html