### PR TITLE
Add hyperlinks from glossary tooltips to the item in the full glossary, with more info

### DIFF
--- a/themes/doks/layouts/shortcodes/tooltip.html
+++ b/themes/doks/layouts/shortcodes/tooltip.html
@@ -23,6 +23,7 @@
         position: relative;
         display: inline;
         border-bottom: 1px dotted black;
+        text-decoration: none !important;  
     }
     .term:hover .definition {
         visibility: visible;
@@ -42,15 +43,17 @@
 
 </style>
 
-<span class="term">&nbsp{{ .Inner }}
-    {{ $searchtermlower := lower .Inner }}
-    {{ $glossarylist := getJSON "content/en/platform/corda/5.0/glossaryitems.json" }}
+{{ $searchtermkebab := lower ( replace (replace .Inner " " "-") "s" "") }}
+{{ $termlink := printf "%s" $searchtermkebab  | printf "%s%s" "#" | printf "%s%s" "https://docs.r3.com/en/platform/corda/5.0/introduction/glossary.html" | safeURL }}
+<a class="term" href ='{{ $termlink }}' >&nbsp{{ .Inner }}
+
+{{ $glossarylist := getJSON "content/en/platform/corda/5.0/glossaryitems.json" }}
     {{ range $term, $value := $glossarylist }}
         {{ $term := lower $term }}
         {{ if eq $term $searchtermlower }} 
-               <span class="definition">{{ $value.definition }}</span>
+               <span class="definition" >{{ $value.definition }}</span>
         {{ else if eq $term (strings.TrimSuffix "s" $searchtermlower) }}
                <span class="definition">{{ $value.definition }}</span>
         {{ end }}
     {{ end }}
-</span>
+    </a>

--- a/themes/doks/layouts/shortcodes/tooltip.html
+++ b/themes/doks/layouts/shortcodes/tooltip.html
@@ -48,13 +48,13 @@
 {{ $termlink := printf "%s" $searchtermkebab  | printf "%s%s" "#" | printf "%s%s" "https://docs.r3.com/en/platform/corda/5.0/introduction/glossary.html" | safeURL }}
 <a class="term" href ='{{ $termlink }}' >&nbsp{{ .Inner }}
 
-    {{ $glossarylist := getJSON "content/en/platform/corda/5.0/glossaryitems.json" }}
-        {{ range $term, $value := $glossarylist }}
-            {{ $term := lower $term }}
-            {{ if eq $term $searchtermlower }} 
-                <span class="definition" >{{ $value.definition }}</span>
-            {{ else if eq $term (strings.TrimSuffix "s" $searchtermlower) }}
-                <span class="definition">{{ $value.definition }}</span>
-            {{ end }}
-        {{ end }}
+{{ $glossarylist := getJSON "content/en/platform/corda/5.0/glossaryitems.json" }}
+{{ range $term, $value := $glossarylist }}
+    {{ $term := lower $term }}
+    {{ if eq $term $searchtermlower }} 
+        <span class="definition" >{{ $value.definition }}</span>
+    {{ else if eq $term (strings.TrimSuffix "s" $searchtermlower) }}
+        <span class="definition">{{ $value.definition }}</span>
+    {{ end }}
+{{ end }}
 </a>

--- a/themes/doks/layouts/shortcodes/tooltip.html
+++ b/themes/doks/layouts/shortcodes/tooltip.html
@@ -48,13 +48,13 @@
 {{ $termlink := printf "%s" $searchtermkebab  | printf "%s%s" "#" | printf "%s%s" "https://docs.r3.com/en/platform/corda/5.0/introduction/glossary.html" | safeURL }}
 <a class="term" href ='{{ $termlink }}' >&nbsp{{ .Inner }}
 
-{{ $glossarylist := getJSON "content/en/platform/corda/5.0/glossaryitems.json" }}
-    {{ range $term, $value := $glossarylist }}
-        {{ $term := lower $term }}
-        {{ if eq $term $searchtermlower }} 
-               <span class="definition" >{{ $value.definition }}</span>
-        {{ else if eq $term (strings.TrimSuffix "s" $searchtermlower) }}
-               <span class="definition">{{ $value.definition }}</span>
+    {{ $glossarylist := getJSON "content/en/platform/corda/5.0/glossaryitems.json" }}
+        {{ range $term, $value := $glossarylist }}
+            {{ $term := lower $term }}
+            {{ if eq $term $searchtermlower }} 
+                <span class="definition" >{{ $value.definition }}</span>
+            {{ else if eq $term (strings.TrimSuffix "s" $searchtermlower) }}
+                <span class="definition">{{ $value.definition }}</span>
+            {{ end }}
         {{ end }}
-    {{ end }}
 </a>

--- a/themes/doks/layouts/shortcodes/tooltip.html
+++ b/themes/doks/layouts/shortcodes/tooltip.html
@@ -57,4 +57,4 @@
                <span class="definition">{{ $value.definition }}</span>
         {{ end }}
     {{ end }}
-    </a>
+</a>

--- a/themes/doks/layouts/shortcodes/tooltip.html
+++ b/themes/doks/layouts/shortcodes/tooltip.html
@@ -43,7 +43,8 @@
 
 </style>
 
-{{ $searchtermkebab := lower ( replace (replace .Inner " " "-") "s" "") }}
+{{ $searchtermlower := lower .Inner }}
+{{ $searchtermkebab := replace (replace $searchtermlower " " "-") "s" "" }}
 {{ $termlink := printf "%s" $searchtermkebab  | printf "%s%s" "#" | printf "%s%s" "https://docs.r3.com/en/platform/corda/5.0/introduction/glossary.html" | safeURL }}
 <a class="term" href ='{{ $termlink }}' >&nbsp{{ .Inner }}
 


### PR DESCRIPTION
.. to the item in the full glossary, which has more info.

Preview here: https://nadine.preview.docs.r3.com/en/platform/corda/5.0.html