### PR TITLE
Niamh25/doc 5700/cli ref table widths

### DIFF
--- a/content/en/platform/corda/5.0/reference/corda-cli/database.md
+++ b/content/en/platform/corda/5.0/reference/corda-cli/database.md
@@ -12,7 +12,16 @@ title: "database"
 # database
 This section lists the {{< tooltip >}}Corda CLI{{< /tooltip >}} `database` arguments. You can use these commands to manually perform setup actions in the database, as described in the [Manual Bootstrapping]({{< relref "../../deploying-operating/deployment/deploying/manual-bootstrapping.md" >}}) section.
 
-| <col style="width:40%"><div style="width:160px">Argument</div> | Description                                                                        |
+<style>
+table th:first-of-type {
+    width: 30%;
+}
+table th:nth-of-type(2) {
+    width: 70%;
+}
+</style>
+
+|Argument| Description                                                                        |
 | --------------------------------------- | ---------------------------------------------------------------------------------- |
 | spec                                    | Generates the database schema from Liquibase.                                      |
 | -c, \-\-clear-change-log                | Deletes the changelogCSV in the PWD to force generation of the SQL files.          |

--- a/content/en/platform/corda/5.0/reference/corda-cli/database.md
+++ b/content/en/platform/corda/5.0/reference/corda-cli/database.md
@@ -12,7 +12,7 @@ title: "database"
 # database
 This section lists the {{< tooltip >}}Corda CLI{{< /tooltip >}} `database` arguments. You can use these commands to manually perform setup actions in the database, as described in the [Manual Bootstrapping]({{< relref "../../deploying-operating/deployment/deploying/manual-bootstrapping.md" >}}) section.
 
-| <div style="width:160px">Argument</div> | Description                                                                        |
+| <col style="width:40%"><div style="width:160px">Argument</div> | Description                                                                        |
 | --------------------------------------- | ---------------------------------------------------------------------------------- |
 | spec                                    | Generates the database schema from Liquibase.                                      |
 | -c, \-\-clear-change-log                | Deletes the changelogCSV in the PWD to force generation of the SQL files.          |

--- a/content/en/platform/corda/5.0/reference/corda-cli/initial-config.md
+++ b/content/en/platform/corda/5.0/reference/corda-cli/initial-config.md
@@ -16,7 +16,16 @@ This section lists the Corda CLI `initial-config` arguments. You can use these c
 
 The `create-user-config` command creates the SQL script to add the {{< tooltip >}}RBAC{{< /tooltip >}} configuration for an initial admin user.
 
-| <div style="width:160px">Argument</div> | Description                                   |
+<style>
+table th:first-of-type {
+    width: 30%;
+}
+table th:nth-of-type(2) {
+    width: 70%;
+}
+</style>
+
+|Argument| Description                                   |
 | --------------------------------------- | --------------------------------------------- |
 | -l, \-\-location                        | The path to write the generated SQL files to. |
 | -p, \-\-password                        | The password of the initial admin user.       |
@@ -39,7 +48,16 @@ corda-cli.cmd initial-config create-user-config -u <INITIAL-ADMIN-USERNAME> -p <
 
 The `create-db-config` command creates the SQL statements to insert the connection manager configuration for the database.
 
-| <div style="width:160px">Argument</div> | Description                                                                                                                                      |
+<style>
+table th:first-of-type {
+    width: 30%;
+}
+table th:nth-of-type(2) {
+    width: 70%;
+}
+</style>
+
+|Argument| Description                                                                                                                                      |
 | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | -a, \-\-is-admin                        | Specifies if this is an admin (DDL) connection. The default value is false.                                                                      |
 | -d, \-\-description                     | Detailed information about the database connection.                                                                                              |

--- a/content/en/platform/corda/5.0/reference/corda-cli/initial-config.md
+++ b/content/en/platform/corda/5.0/reference/corda-cli/initial-config.md
@@ -73,7 +73,16 @@ corda-cli.cmd initial-config create-db-config -u <RBAC-USERNAME> -p <RBAC-PASSWO
 
 The `create-crypto-config` command creates the SQL statements to insert the initial crypto configuration for the database. This operation must be performed after the cluster database is initialized but before the cluster is started.
 
-| <div style="width:160px">Argument</div> | Description                                                                                                                                      |
+<style>
+table th:first-of-type {
+    width: 30%;
+}
+table th:nth-of-type(2) {
+    width: 70%;
+}
+</style>
+
+|Argument | Description                                                                                                                                      |
 | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | -l, \-\-location                        | The path to write the generated SQL files to.                                                                                                    |
 | -p, \-\-passphrase                      | The passphrase for the encrypting secrets service.  This must match the value specified in the Corda deployment configuration for the database worker. |

--- a/content/en/platform/corda/5.0/reference/corda-cli/mgm.md
+++ b/content/en/platform/corda/5.0/reference/corda-cli/mgm.md
@@ -29,7 +29,16 @@ corda-cli.cmd mgm groupPolicy
 
 Alternatively, use the following command line arguments to define the static network section of the GroupPolicy:
 
-| <div style="width:160px">Argument</div> | Description                                                                                                                                                        |
+<style>
+table th:first-of-type {
+    width: 30%;
+}
+table th:nth-of-type(2) {
+    width: 70%;
+}
+</style>
+
+|Argument| Description                                                                                                                                                        |
 | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | \-\-file, -f                            | The path to a JSON or YAML file that contains static network information; see [Generating GroupPolicy Using File Input](#generating-groupPolicy-using-file-input). |
 | \-\-name                                | The {{< tooltip >}}X.500{{< /tooltip >}} name of the {{< tooltip >}}member{{< /tooltip >}}; see [Generating GroupPolicy Using String Parameters](#generating-grouppolicy-using-string-parameters).                               |

--- a/content/en/platform/corda/5.0/reference/corda-cli/package.md
+++ b/content/en/platform/corda/5.0/reference/corda-cli/package.md
@@ -12,7 +12,16 @@ title: "package"
 # package
 This section lists the {{< tooltip >}}Corda CLI{{< /tooltip >}} `package` arguments. You can use these commands to execute operations for working with {{< tooltip >}}CPB{{< /tooltip >}} and {{< tooltip >}}CPI{{< /tooltip >}} files, as described in the [Packaging section for CorDapp Developers]({{< relref "../../developing-applications/packaging/_index.md">}}).
 
-| <div style="width:160px">Argument</div> | Description                                        |
+<style>
+table th:first-of-type {
+    width: 30%;
+}
+table th:nth-of-type(2) {
+    width: 70%;
+}
+</style>
+
+| Argument | Description                                        |
 | --------------------------------------- | -------------------------------------------------- |
 | \-\-create-cpb                          | Creates a CPB file. See [create-cpb](#create-cpb). |
 | \-\-create-cpi                          | Creates a CPI file. See [create-cpi](#create-cpi). |
@@ -21,7 +30,16 @@ This section lists the {{< tooltip >}}Corda CLI{{< /tooltip >}} `package` argume
 
 The `create-cpb` argument creates a CPB file from a set of {{< tooltip >}}CPK{{< /tooltip >}} files using the following arguments:
 
-| <div style="width:160px">Argument</div> | Description                                        |
+<style>
+table th:first-of-type {
+    width: 30%;
+}
+table th:nth-of-type(2) {
+    width: 70%;
+}
+</style>
+
+| Argument | Description                                        |
 | --------------------------------------- | -------------------------------------------------- |
 | \-\-cpb-name                            | Specifies a name for the CPB.                      |
 | \-\-cpb-version                         | Specifies the CPB version.                         |
@@ -63,7 +81,16 @@ For example:
 
 The `create-cpi` argument creates a CPI file using the following arguments:
 
-| <div style="width:160px">Argument</div> | Description                                                                                 |
+<style>
+table th:first-of-type {
+    width: 30%;
+}
+table th:nth-of-type(2) {
+    width: 70%;
+}
+</style>
+
+| Argument | Description                                                                                 |
 | --------------------------------------- | ------------------------------------------------------------------------------------------- |
 | \-\-cpb                                 | Specifies the CPB file to include in the CPI. This can be omitted when creating an MGM CPI.                                              |
 | \-\-group-policy                        | Specifies the {{< tooltip >}}group policy{{< /tooltip >}}file to include in the CPI. |

--- a/content/en/platform/corda/5.0/reference/corda-cli/secret-config.md
+++ b/content/en/platform/corda/5.0/reference/corda-cli/secret-config.md
@@ -14,7 +14,16 @@ title: "secret-config"
 
 This section lists the {{< tooltip >}}Corda CLI{{< /tooltip >}} `secret-config` arguments. You can use these commands to generate the configuration for use with the [configured secrets lookup service]({{< relref "../../deploying-operating/deployment/deploying/_index.md#encryption" >}}).
 
-| <div style="width:160px">Argument</div> | Description                                                                             |
+<style>
+table th:first-of-type {
+    width: 30%;
+}
+table th:nth-of-type(2) {
+    width: 70%;
+}
+</style>
+
+| Argument | Description                                                                             |
 | --------------------------------------- | --------------------------------------------------------------------------------------- |
 | \-\-create                              | Encrypts a configuration value for the secrets lookup service. See [create](#create).   |
 | \-\-decrypt                             | Decrypts a value for the Corda default secrets lookup service. See [decrypt](#decrypt). |
@@ -23,7 +32,16 @@ This section lists the {{< tooltip >}}Corda CLI{{< /tooltip >}} `secret-config` 
 
 The `create` argument generates the configuration string for use with the specified secrets lookup service using the following arguments:
 
-| <div style="width:160px">Argument</div> | Description                                                                                                                                                                                                                                                                                                                                                                      |
+<style>
+table th:first-of-type {
+    width: 30%;
+}
+table th:nth-of-type(2) {
+    width: 70%;
+}
+</style>
+
+| Argument | Description                                                                                                                                                                                                                                                                                                                                                                      |
 | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | \-p, \-\-passphrase                     | The passphrase for the default secrets lookup service. This must be the same value in the [deployment configuration]({{< relref "../../deploying-operating/deployment/deploying/_index.md#default-secrets-service" >}}).                                                                                                                                                                 |
 | \-s, \-\-salt                           | The salt for the default secrets lookup service. This must be the same value in the [deployment configuration]({{< relref "../../deploying-operating/deployment/deploying/_index.md#default-secrets-service" >}}).                                                                                                                                                                       |
@@ -65,7 +83,16 @@ For example, to generate the configuration to use to specify a value stored in a
 
 The `decrypt` argument decrypts a value encrypted by the Corda default secrets lookup service.
 
-| <div style="width:160px">Argument</div> | Description                                                                                                                                                                                                      |
+<style>
+table th:first-of-type {
+    width: 30%;
+}
+table th:nth-of-type(2) {
+    width: 70%;
+}
+</style>
+
+| Argument | Description                                                                                                                                                                                                      |
 | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | \-p, \-\-passphrase                     | The passphrase for the default secrets lookup service. This must be the same value in the [deployment configuration]({{< relref "../../deploying-operating/deployment/deploying/_index.md#default-secrets-service" >}}). |
 | \-s, \-\-salt                           | The salt for the default secrets lookup service. This must be the same value in the [deployment configuration]({{< relref "../../deploying-operating/deployment/deploying/_index.md#default-secrets-service" >}}).       |

--- a/content/en/platform/corda/5.0/reference/corda-cli/topic.md
+++ b/content/en/platform/corda/5.0/reference/corda-cli/topic.md
@@ -12,7 +12,16 @@ title: "topic"
 # topic
 This section lists the {{< tooltip >}}Corda CLI{{< /tooltip >}} `topic` arguments. You can use these commands to manually create or delete topics in {{< tooltip >}}Kafka{{< /tooltip >}}, as described in the [Manual Bootstrapping]({{< relref "../../deploying-operating/deployment/deploying/manual-bootstrapping.md" >}}) section.
 
-| <div style="width:160px">Argument</div> | Description                                                                                                                                                       |
+<style>
+table th:first-of-type {
+    width: 30%;
+}
+table th:nth-of-type(2) {
+    width: 70%;
+}
+</style>
+
+| Argument | Description                                                                                                                                                       |
 | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | -b, \-\-bootstrap-server                | The address of the bootstrap server.                                                                                                                              |
 | -k, \-\-kafka-config                    | The path to the Kafka configuration file.                                                                                                                         |


### PR DESCRIPTION
All tables in the CLI reference sections have the same column width to make them uniformed.