### PR TITLE
Add new site param for Corda 5 versions

### DIFF
--- a/themes/doks/config/_default/params.toml
+++ b/themes/doks/config/_default/params.toml
@@ -1,3 +1,6 @@
+# Version
+corda5versions = ["Corda 5.0", "Corda 5.1"]
+
 # Meta Data for SEO
 
 ## Homepage

--- a/themes/doks/layouts/_default/_markup/render-heading.html
+++ b/themes/doks/layouts/_default/_markup/render-heading.html
@@ -20,7 +20,8 @@
   }
 </script>
 
-{{ if ne .Page.Params.version "Corda 5.0" }}
+{{ $c5 := in .Site.Params.corda5versions .Page.Params.version }}
+{{ if eq $c5 false }}
   {{ if ne .Level 1 }}
     <h{{ .Level }} id="{{ .Anchor | safeURL }}"  class="link-heading">
       <a href="#{{ .Anchor | safeURL }}">

--- a/themes/doks/layouts/_default/_markup/render-heading.html
+++ b/themes/doks/layouts/_default/_markup/render-heading.html
@@ -20,7 +20,7 @@
   }
 </script>
 
-{{ $c5 := in .Site.Params.corda5versions .Page.Params.version }}
+{{ $c5 := in site.Params.corda5versions .Page.Params.version }}
 {{ if eq $c5 false }}
   {{ if ne .Level 1 }}
     <h{{ .Level }} id="{{ .Anchor | safeURL }}"  class="link-heading">

--- a/themes/doks/layouts/_default/list.html
+++ b/themes/doks/layouts/_default/list.html
@@ -21,7 +21,8 @@
 				</nav>
 			{{ end }}
 			{{ end }}
-			{{ if ne .Page.Params.version "Corda 5.0"}}			
+			{{ $c5 := in .Site.Params.corda5versions .Page.Params.version }}
+			{{ if eq $c5 false }}			
     			<h1>{{ .Title }}</h1>
 			{{ end }}
       {{ if .Site.Params.editPage -}}

--- a/themes/doks/layouts/_default/single.html
+++ b/themes/doks/layouts/_default/single.html
@@ -9,12 +9,13 @@
       </div>
 		</div>
     {{ end -}}
-		{{ if ne .Parent.Page.Params.version "Corda 5.0" }}
+		{{ $c5 := in .Site.Params.corda5versions .Page.Params.version }}
+		{{ if eq $c5 false }}
 			<nav class="docs-toc d-none d-xl-block col-xl-3" aria-label="Secondary navigation">
 				{{ partial "sidebar/docs-toc.html" . }}
 			</nav>
 		{{ end -}}
-		{{ if ne .Parent.Page.Params.version "Corda 5.0"}}
+		{{ if eq $c5 false }}
 			<main class="docs-content col-lg-11 col-xl-9 mx-lg-auto">
 		{{ else -}}
 			<main class="docs-content col-lg-11 col-xl-12 mx-lg-auto">
@@ -28,7 +29,7 @@
 					</ol>
 				</nav>
 			{{ end }}
-			{{ if ne .Parent.Page.Params.version "Corda 5.0"}}			
+			{{ if eq $c5 false }}			
     			<h1>{{ .Title }}</h1>
 			{{ end }}
       {{ if .Site.Params.editPage -}}


### PR DESCRIPTION
There are several differences in the way Corda 5 content is rendered. For example, H1s don't come from the front matter and there is no right-hand menu.
This PR creates a new site parameter to contain a list of the Corda 5 doc versions. This variable is now checked when determining how to render content. As a result, when there is a new Corda 5 version, this now only needs to be added to the site parameter and not in multiple places.

Preview here: https://nadine.preview.docs.r3.com/en/platform/corda/5.0.html