### PR TITLE
Update the response from MGM virtual node creation

### DIFF
--- a/content/en/platform/corda/5.0/application-networks/creating/members/virtual-node.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/members/virtual-node.md
@@ -31,7 +31,7 @@ You can use the `requestId` from the response to check that the virtual node was
 curl -k -u $REST_API_USER:$REST_API_PASSWORD -X GET $REST_API_URL/virtualnode/status/<request-ID>
 ```
 
-This request returns a JSON object with `status` set to `SUCCEEDED` once the operation is complete. You may have to call the `/virtualnode/status` endpoint multiple times until you receive the `SUCCEEDED` status. Once complete, to save the ID of the virtual node for future use, run the following command, replacing `<resource-ID>` with the ID returned in the received response:
+Once the operation is complete, this request returns a JSON object with `status` set to `SUCCEEDED`. You may have to call the `/virtualnode/status` endpoint multiple times until you receive the `SUCCEEDED` status. Once complete, to save the ID of the virtual node for future use, run the following command, replacing `<resource-ID>` with the ID returned in the received response:
 
 ```shell
 export HOLDING_ID = <resource-ID>
@@ -57,7 +57,7 @@ You can use the `requestId` from the response to check that the virtual node was
 $VIRTUAL_NODE_RESPONSE_STATUS = Invoke-RestMethod -SkipCertificateCheck  -Headers @{Authorization=("Basic {0}" -f $AUTH_INFO)} -Uri "$REST_API_URL/virtualnode/status/$($VIRTUAL_NODE_RESPONSE.requestId)" -Method Get
 ```
 
-This request returns a JSON object with `status` set to `SUCCEEDED` once the operation is complete. You may have to call the `/virtualnode/status` endpoint multiple times until you receive the `SUCCEEDED` status. Once complete, to save the ID of the virtual node for future use, run the following command:
+Once the operation is complete, this request returns a JSON object with `status` set to `SUCCEEDED`. You may have to call the `/virtualnode/status` endpoint multiple times until you receive the `SUCCEEDED` status. Once complete, to save the ID of the virtual node for future use, run the following command:
 
 ```shell
 $HOLDING_ID = $VIRTUAL_NODE_RESPONSE_STATUS.resourceId

--- a/content/en/platform/corda/5.0/application-networks/creating/members/virtual-node.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/members/virtual-node.md
@@ -25,8 +25,7 @@ export CPI_CHECKSUM=<CPI-checksum>
 export X500_NAME="C=GB, L=London, O=Alice"
 curl -k -u $REST_API_USER:$REST_API_PASSWORD -d '{"request": {"cpiFileChecksum": "'$CPI_CHECKSUM'", "x500Name": "'$X500_NAME'"}}' $REST_API_URL/virtualnode
 ```
-
-Check that the virtual node was created successfully by running the following, replacing `<request-ID>` with the ID returned in the received response:
+You can use the `requestId` from the response to check that the virtual node was created successfully. Run the following, replacing `<request-ID>` with the ID received:
 
 ```shell
 curl -k -u $REST_API_USER:$REST_API_PASSWORD -X GET $REST_API_URL/virtualnode/status/<request-ID>
@@ -51,7 +50,8 @@ $VIRTUAL_NODE_RESPONSE = Invoke-RestMethod -SkipCertificateCheck  -Headers @{Aut
     }
 })
 ```
-Check that the virtual node was created successfully by running the following:
+
+You can use the `requestId` from the response to check that the virtual node was created successfully by running the following:
 
 ```shell
 $VIRTUAL_NODE_RESPONSE_STATUS = Invoke-RestMethod -SkipCertificateCheck  -Headers @{Authorization=("Basic {0}" -f $AUTH_INFO)} -Uri "$REST_API_URL/virtualnode/status/$($VIRTUAL_NODE_RESPONSE.requestId)" -Method Get

--- a/content/en/platform/corda/5.0/application-networks/creating/mgm/virtual-node.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/mgm/virtual-node.md
@@ -27,7 +27,7 @@ export X500_NAME="C=GB, L=London, O=MGM"
 curl -k -u $REST_API_USER:$REST_API_PASSWORD -d '{ "request": {"cpiFileChecksum": "'$CPI_CHECKSUM'", "x500Name": "'$X500_NAME'"}}' $REST_API_URL/virtualnode
 ```
 
-Check that the virtual node was created successfully by running the following, replacing `<request-ID>` with the ID returned in the received response:
+You can use the `requestId` from the response to check that the virtual node was created successfully. Run the following, replacing `<request-ID>` with the ID received:
 
 ```shell
 curl -k -u $REST_API_USER:$REST_API_PASSWORD -X GET $REST_API_URL/virtualnode/status/<request-ID>
@@ -53,7 +53,7 @@ $VIRTUAL_NODE_RESPONSE = Invoke-RestMethod -SkipCertificateCheck  -Headers @{Aut
 })
 ```
 
-Check that the virtual node was created successfully by running the following:
+You can use the `requestId` from the response to check that the virtual node was created successfully by running the following:
 
 ```shell
 $VIRTUAL_NODE_RESPONSE_STATUS = Invoke-RestMethod -SkipCertificateCheck  -Headers @{Authorization=("Basic {0}" -f $AUTH_INFO)} -Uri "$REST_API_URL/virtualnode/status/$($VIRTUAL_NODE_RESPONSE.requestId)" -Method Get

--- a/content/en/platform/corda/5.0/application-networks/creating/mgm/virtual-node.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/mgm/virtual-node.md
@@ -36,7 +36,7 @@ curl -k -u $REST_API_USER:$REST_API_PASSWORD -X GET $REST_API_URL/virtualnode/st
 This request returns a JSON object with `status` set to `SUCCEEDED` once the operation is complete. You may have to call the `/virtualnode/status` endpoint multiple times until you receive the `SUCCEEDED` status. Once complete, to save the ID of the virtual node for future use, run the following command, replacing `<resource-ID>` with the ID returned in the received response:
 
 ```shell
-export HOLDING_ID = <resource-ID>
+export MGM_HOLDING_ID = <resource-ID>
 ```
 
 ## Create a Virtual Node on Windows

--- a/content/en/platform/corda/5.0/application-networks/creating/mgm/virtual-node.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/mgm/virtual-node.md
@@ -59,7 +59,7 @@ You can use the `requestId` from the response to check that the virtual node was
 $VIRTUAL_NODE_RESPONSE_STATUS = Invoke-RestMethod -SkipCertificateCheck  -Headers @{Authorization=("Basic {0}" -f $AUTH_INFO)} -Uri "$REST_API_URL/virtualnode/status/$($VIRTUAL_NODE_RESPONSE.requestId)" -Method Get
 ```
 
-This request returns a JSON object with `status` set to `SUCCEEDED` once the operation is complete. You may have to call the `/virtualnode/status` endpoint multiple times until you receive the `SUCCEEDED` status. Once complete, to save the ID of the virtual node for future use, run the following command:
+Once the operation is complete, this request returns a JSON object with `status` set to `SUCCEEDED`. You may have to call the `/virtualnode/status` endpoint multiple times until you receive the `SUCCEEDED` status. Once complete, to save the ID of the virtual node for future use, run the following command:
 
 ```shell
 $HOLDING_ID = $VIRTUAL_NODE_RESPONSE_STATUS.resourceId

--- a/content/en/platform/corda/5.0/application-networks/creating/mgm/virtual-node.md
+++ b/content/en/platform/corda/5.0/application-networks/creating/mgm/virtual-node.md
@@ -33,7 +33,7 @@ You can use the `requestId` from the response to check that the virtual node was
 curl -k -u $REST_API_USER:$REST_API_PASSWORD -X GET $REST_API_URL/virtualnode/status/<request-ID>
 ```
 
-This request returns a JSON object with `status` set to `SUCCEEDED` once the operation is complete. You may have to call the `/virtualnode/status` endpoint multiple times until you receive the `SUCCEEDED` status. Once complete, to save the ID of the virtual node for future use, run the following command, replacing `<resource-ID>` with the ID returned in the received response:
+Once the operation is complete, this request returns a JSON object with `status` set to `SUCCEEDED`. You may have to call the `/virtualnode/status` endpoint multiple times until you receive the `SUCCEEDED` status. Once complete, to save the ID of the virtual node for future use, run the following command, replacing `<resource-ID>` with the ID returned in the received response:
 
 ```shell
 export MGM_HOLDING_ID = <resource-ID>


### PR DESCRIPTION
The request to create a virtual node no longer "returns the details of the new virtual node as JSON", but rather a requestId which can be used in GET /api/v1/virtualnode/status/{requestId} to get an update.
This was not reflected in the MGM section.