### PR TITLE
Title of version landing pages displays the version twice

### DIFF
--- a/themes/doks/layouts/partials/head/seo.html
+++ b/themes/doks/layouts/partials/head/seo.html
@@ -18,7 +18,11 @@
   <title>
     {{ .Title }} 
     {{ if .Params.version }}
-      {{ .Site.Params.titleSeparator }} {{ .Params.version }}
+      {{ if eq .Params.version .Title }}
+        {{ .Site.Params.titleSeparator }} Home
+      {{ else }}
+        {{ .Site.Params.titleSeparator }} {{ .Params.version }}
+      {{ end }}
     {{ else }}
       {{ .Site.Params.titleSeparator }} {{.Parent.Page.Params.version}}
     {{ end }}


### PR DESCRIPTION
For example:

![image](https://github.com/corda/corda-docs-portal/assets/103633799/87bf38ba-f80f-4118-91c0-398b7f7e7988)

After:

![image](https://github.com/corda/corda-docs-portal/assets/103633799/5cdf7bcb-decb-47f4-9559-df8697af375e)


Preview here: https://nadine.preview.docs.r3.com/