### PR TITLE
The "Next" navigation was not displayed on the footer of version landing pages

### DIFF
--- a/content/en/platform/corda/5.0/_index.md
+++ b/content/en/platform/corda/5.0/_index.md
@@ -1,13 +1,15 @@
 ---
 date: '2022-08-17'
 description: "Documentation for the next-gen release of Corda"
-title: "Corda 5.0"
+title: "Next-Gen Corda 5.0"
 project: corda
 version: 'Corda 5.0'
 section_menu: corda5
 menu:
   versions:
     weight: -652
+  corda5:
+    weight: -100
 aliases: 5.0-beta.html   
 ---
 # Next-Gen {{< version >}}

--- a/themes/doks/layouts/partials/main/docs-navigation.html
+++ b/themes/doks/layouts/partials/main/docs-navigation.html
@@ -17,7 +17,7 @@
 {{ define "iterate-menu-item" }}
 {{ $page := .page }}
 
-{{ $sectionMenuForThisPage := or $page.Parent.Page.Params.section_menu $page.Params.section_menu}}
+{{ $sectionMenuForThisPage := or $page.Params.section_menu $page.Parent.Page.Params.section_menu}}
 
 {{ with .entry }}
 
@@ -68,7 +68,7 @@
 
 {{/* Iterate the menu using the template */}}
 
-{{ $sectionMenuForThisPage := or .Parent.Page.Params.section_menu .Page.Params.section_menu}}
+{{ $sectionMenuForThisPage := or .Page.Params.section_menu .Parent.Page.Params.section_menu}}
 {{ if $sectionMenuForThisPage }}
 {{ $menuEntries := index .Site.Menus $sectionMenuForThisPage}}
 {{ $page := . }}


### PR DESCRIPTION
Preview here: https://corda5.preview.docs.r3.com/