### PR TITLE
making landing page cards clickable

### DIFF
--- a/themes/doks/assets/scss/common/_global.scss
+++ b/themes/doks/assets/scss/common/_global.scss
@@ -89,8 +89,8 @@ a.btn:focus {
 }
 
 .section {
-  padding-top: 5rem;
-  padding-bottom: 5rem;
+  padding-top: 1rem;
+  padding-bottom: 2.5rem;
 }
 
 .section-md {
@@ -318,7 +318,7 @@ body {
       background-color: $white;
 
       .card-body {
-        padding: 1rem 2.5rem 0;
+        padding: 0.1rem 2.5rem 0;
       }
 
       h5 {

--- a/themes/doks/layouts/index.html
+++ b/themes/doks/layouts/index.html
@@ -43,7 +43,7 @@
               <p>Everything that CorDapp Developers, Cluster Administrators, and Network Operators need to know about the next-generation of Corda.</p>
             </div>
             <div class="card-footer">
-              <a href="en/platform/corda/5.0.html" class="btn rounded">Start Exploring</a>
+              <a href="en/platform/corda/5.0.html" class="btn rounded stretched-link">Start Exploring</a>
             </div>
           </div>
         </div>
@@ -109,7 +109,7 @@
             <p>Javadocs and KDocs for all publicly-exposed APIs in the Corda 5 and Corda 4 series: Corda OS, Corda Enterprise, and Corda Enterprise Network Manager (CENM).</p>
           </div>
           <div class="card-footer">
-            <a href="en/api-ref.html" class="btn rounded external">API references</a>
+            <a href="en/api-ref.html" class="btn rounded stretched-link">API references</a>
           </div>
         </div>
       </div>
@@ -120,7 +120,7 @@
             <p>Supercharge your Corda operations and CorDapp design and development with extras. Find the Tokens SDK, Accounts Library, CorDapp Design Language, node and flow management consoles, and more.</p>
           </div>
           <div class="card-footer">
-            <a href="en/tools.html" class="btn rounded">Explore tools and add-ons</a>
+            <a href="en/tools.html" class="btn rounded stretched-link">Explore tools and add-ons</a>
           </div>
         </div>
       </div>
@@ -131,7 +131,7 @@
             <p>Join the new R3 Developer Platform - the most powerful blockchain community for developers.</p>
           </div>
           <div class="card-footer">
-            <a href="https://developer.r3.com" target="_blank" class="btn rounded external">Join R3 Developers</a>
+            <a href="https://developer.r3.com" target="_blank" class="btn rounded stretched-link">Join R3 Developers</a>
           </div>
         </div>
       </div>
@@ -142,7 +142,7 @@
             <p>CorDapp Design Language (CDL) is a set of diagrammatic views you can use to concisely and accurately guide the design of your CorDapp.</p>
           </div>
           <div class="card-footer">
-            <a href="en/tools/cdl/cdl-index.html" class="btn rounded external">Read the CDL docs</a>
+            <a href="en/tools/cdl/cdl-index.html" class="btn rounded stretched-link">Read the CDL docs</a>
           </div>
         </div>
       </div>

--- a/themes/doks/layouts/index.html
+++ b/themes/doks/layouts/index.html
@@ -122,7 +122,7 @@
             <p>Supercharge your Corda operations and CorDapp design and development with extras. Find the Tokens SDK, Accounts Library, CorDapp Design Language, node and flow management consoles, and more.</p>
           </div>
           <div class="card-footer">
-            <a href="en/tools.html" class="btn rounded stretched-link">Explore tools and add-ons</a>
+            <a href="en/tools.html" class="btn rounded stretched-link">Explore Tools & Add-Ons</a>
           </div>
         </div>
       </div>

--- a/themes/doks/layouts/index.html
+++ b/themes/doks/layouts/index.html
@@ -133,7 +133,7 @@
             <p>Join the new R3 Developer Platform - the most powerful blockchain community for developers.</p>
           </div>
           <div class="card-footer">
-            <a href="https://developer.r3.com" target="_blank" class="btn rounded stretched-link">Join R3 Developers</a>
+            <a href="https://developer.r3.com" target="_blank" class="btn rounded stretched-link">Join the R3 Developer Community</a>
           </div>
         </div>
       </div>

--- a/themes/doks/layouts/index.html
+++ b/themes/doks/layouts/index.html
@@ -39,7 +39,7 @@
         <div class="col">
           <div class="card h-100">
             <div class="card-body">
-              <h3 class="card-title">Corda 5.0</h3>
+              <h3 class="card-title">Corda 5</h3>
               <p>Everything that CorDapp Developers, Cluster Administrators, and Network Operators need to know about the next-generation of Corda.</p>
             </div>
             <div class="card-footer">

--- a/themes/doks/layouts/index.html
+++ b/themes/doks/layouts/index.html
@@ -61,7 +61,7 @@
           </div>
         </div>
 
-    </div>
+    <!--</div>
     <div class="row">
       <div class="col">
         <div class="carousel-btns d-none">
@@ -99,8 +99,10 @@
           </div>
         </div>
       </div>
-    </div>
-
+    </div> -->
+  
+  </section>
+  <section class="section">
     <div class="row row-cols-1 row-cols-md-2 row-cols-xl-4 g-5">
       <div class="col">
         <div class="card no-border h-100">

--- a/themes/doks/layouts/index.html
+++ b/themes/doks/layouts/index.html
@@ -109,7 +109,7 @@
             <p>Javadocs and KDocs for all publicly-exposed APIs in the Corda 5 and Corda 4 series: Corda OS, Corda Enterprise, and Corda Enterprise Network Manager (CENM).</p>
           </div>
           <div class="card-footer">
-            <a href="en/api-ref.html" class="btn rounded stretched-link">API references</a>
+            <a href="en/api-ref.html" class="btn rounded stretched-link">API References</a>
           </div>
         </div>
       </div>

--- a/themes/doks/layouts/index.html
+++ b/themes/doks/layouts/index.html
@@ -111,7 +111,7 @@
             <p>Javadocs and KDocs for all publicly-exposed APIs in the Corda 5 and Corda 4 series: Corda OS, Corda Enterprise, and Corda Enterprise Network Manager (CENM).</p>
           </div>
           <div class="card-footer">
-            <a href="en/api-ref.html" class="btn rounded stretched-link">API References</a>
+            <a href="en/api-ref.html" class="btn rounded stretched-link">Explore API References</a>
           </div>
         </div>
       </div>

--- a/themes/doks/layouts/index.html
+++ b/themes/doks/layouts/index.html
@@ -144,7 +144,7 @@
             <p>CorDapp Design Language (CDL) is a set of diagrammatic views you can use to concisely and accurately guide the design of your CorDapp.</p>
           </div>
           <div class="card-footer">
-            <a href="en/tools/cdl/cdl-index.html" class="btn rounded stretched-link">Read the CDL docs</a>
+            <a href="en/tools/cdl/cdl-index.html" class="btn rounded stretched-link">Read the CDL Docs</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Preview: https://paul.preview.docs.r3.com/

Our landing page cards are clickable, yet the click doesn't lead anywhere. Instead, the links are buttons within the card <p> element. This is not very intuitive. As part of a larger set of potential changes to landing page:

1. Cards with one link are now entirely clickable.
2. The C5 card title was **Corda 5.0**, whereas the C4 card was **Corda 4**. The C5 card is now **Corda 5**.
3. The two highlighted cards (red) are not external links any more. The external symbol is removed accordingly.
4. The highlighted card (blue) is still external, but there was a problem adding the external symbol AND making the entire card clickable. For now, I have run with making the entire clickable and I have a question in with FE team around adding the external symbol too.
<img width="1465" alt="image" src="https://github.com/corda/corda-docs-portal/assets/112863914/a17d64be-3fc5-4fd0-b30a-c0cf4fdb3095">
