### PR TITLE
delete Docs link & other footer links

### DIFF
--- a/themes/doks/assets/scss/layouts/_footer.scss
+++ b/themes/doks/assets/scss/layouts/_footer.scss
@@ -4,7 +4,7 @@ footer {
 
   .footer-links {
     display: flex;
-    width: 100%;
+    width: 75%;
     flex-direction: column;
     flex-wrap: wrap;
     align-content: space-between;

--- a/themes/doks/layouts/partials/footer/footer.html
+++ b/themes/doks/layouts/partials/footer/footer.html
@@ -5,7 +5,6 @@
                 <div class="footer-logo">
                   <a href="/" target="_blank" title="R3 Docs">
                     <img src="{{ "images/r3.svg" | absURL }}" alt="R3 Docs" width="74" height="56">
-                    <span class="badge bg-secondary docs">Docs</span>
                   </a>
                   <ul class="list-inline mt-4">
                     {{ range .Site.Menus.social -}}
@@ -20,12 +19,12 @@
                       <li><a href="https://developer.r3.com/" target="_blank">Developer platform</a></li>
                       <li><a href="https://developer.r3.com/developer-program" target="_blank">Developer program</a></li>
                       <li><a href="https://community.r3.com/" target="_blank">Community forum</a></li>
-                      <li><a href="https://developer.r3.com/events" target="_blank">Events</a></li>
+                      <!-- <li><a href="https://developer.r3.com/events" target="_blank">Events</a></li> -->
                       <li><a href="https://developer.r3.com/blog" target="_blank">Blog</a></li>
                       <li><a href="https://developer.r3.com/videos" target="_blank">Videos</a></li>
                       <li><a href="https://developer.r3.com/resources" target="_blank">Resources</a></li>
                       <li><a href="https://developer.r3.com/support" target="_blank">Support</a></li>
-                      <li><a href="https://www.r3.com/careers/" target="_blank" rel="noopener noopener">Careers</a></li>
+                      <!-- <li><a href="https://www.r3.com/careers/" target="_blank" rel="noopener noopener">Careers</a></li> -->
                       <li><a href="https://www.r3.com/" target="_blank" rel="noopener noopener">About R3</a></li>
                     </ul>
                 </div>

--- a/themes/doks/layouts/partials/footer/footer.html
+++ b/themes/doks/layouts/partials/footer/footer.html
@@ -3,7 +3,7 @@
         <div class="container-fluid">
             <div class="row d-flex">
                 <div class="footer-logo">
-                  <a href="/" target="_blank" title="R3 Docs">
+                  <a href="/" title="R3 Docs">
                     <img src="{{ "images/r3.svg" | absURL }}" alt="R3 Docs" width="74" height="56">
                   </a>
                   <ul class="list-inline mt-4">


### PR DESCRIPTION
There will be lots of changes to footer, header, and landing page of docs over next week or so. These changes are best achieved in iterative approach. There are lots of other things still to change even for this footer, so this is not the final state.

1. Remove Docs link from footer.
2. Remove two other links from right side of footer.
3. Tweak footer style to close up the columns.

<img width="1504" alt="image" src="https://github.com/corda/corda-docs-portal/assets/112863914/6396c91c-ca49-4661-be35-12970b61b495">

<img width="1508" alt="image" src="https://github.com/corda/corda-docs-portal/assets/112863914/74c7a321-47b4-4ec3-8484-01932880f139">
