### PR TITLE
DOC-5958 - updated the Enterprise platform support matrix as follows:…

### DIFF
--- a/content/en/platform/corda/4.10/enterprise/platform-support-matrix.md
+++ b/content/en/platform/corda/4.10/enterprise/platform-support-matrix.md
@@ -147,7 +147,7 @@ The Docker images used for the Kubernetes deployment are listed below for refere
 |                               | Driver version 4.21.1    | Driver version 4.21.1    | Driver version 4.21.1      | Driver version 4.21.1       |
 | Gemalto Luna (firmware)       | Firmware version 7.0.3   | Firmware version 7.0.3   | Firmware version 7.0.3     | Firmware version 7.0.3      |
 | Gemalto Luna driver with Corda 4.9.6 and earlier, 4.10, 4.10.1  | Driver version 7.3 | Driver version 7.3 | Driver version 7.3 | Driver version 7.3 |
-| Gemalto Luna driver with Corda 4.9.7 and later versions of 4.9.*, 4.10.2  | Driver version 10.4.0 | Driver version 10.4.0 | Driver version 10.4.0 | Driver version 10.4.0 |
+| Gemalto Luna driver with Corda 4.9.7 and later versions of 4.9.*, plus 4.10.2 and later versions of 4.10.*  | Driver version 10.4.0 | Driver version 10.4.0 | Driver version 10.4.0 | Driver version 10.4.0 |
 | FutureX Vectera Plus          | Firmware version 6.1.5.8 | Firmware version 6.1.5.8 | Firmware version 6.1.5.8   | Firmware version 6.1.5.8    |
 |                               | PKCS#11 version 3.1      | PKCS#11 version 3.1      | PKCS#11 version 3.1        | PKCS#11 version 3.1         |
 |                               | FXJCA version 1.17       | FXJCA version 1.17       | FXJCA version 1.17         | FXJCA version 1.17          |


### PR DESCRIPTION
… 'Gemalto Luna driver with Corda 4.9.7 and later versions of 4.9.*, and 4.10.2 and later versions of 4.10.*.'