### PR TITLE
Update GitHub source paths to 5.1 versions

### DIFF
--- a/content/en/platform/corda/5.1/deploying-operating/config/fields/crypto.md
+++ b/content/en/platform/corda/5.1/deploying-operating/config/fields/crypto.md
@@ -10,4 +10,4 @@ menu:
 section_menu: corda51
 ---
 # corda.crypto
-{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.0/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json" >}}
+{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.1/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json" >}}

--- a/content/en/platform/corda/5.1/deploying-operating/config/fields/db.md
+++ b/content/en/platform/corda/5.1/deploying-operating/config/fields/db.md
@@ -10,4 +10,4 @@ menu:
 section_menu: corda51
 ---
 # corda.db
-{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.0/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json" >}}
+{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.1/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json" >}}

--- a/content/en/platform/corda/5.1/deploying-operating/config/fields/externalMessaging.md
+++ b/content/en/platform/corda/5.1/deploying-operating/config/fields/externalMessaging.md
@@ -10,4 +10,4 @@ menu:
 section_menu: corda51
 ---
 # corda.externalMessaging {{< enterprise-icon >}}
-{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.0/data/config-schema/src/main/resources/net/corda/schema/configuration/externalMessaging/1.0/corda.externalMessaging.json" >}}
+{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.1/data/config-schema/src/main/resources/net/corda/schema/configuration/externalMessaging/1.0/corda.externalMessaging.json" >}}

--- a/content/en/platform/corda/5.1/deploying-operating/config/fields/flow.md
+++ b/content/en/platform/corda/5.1/deploying-operating/config/fields/flow.md
@@ -10,4 +10,4 @@ menu:
 section_menu: corda51
 ---
 # corda.flow
-{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.0/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json" >}}
+{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.1/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json" >}}

--- a/content/en/platform/corda/5.1/deploying-operating/config/fields/ledger-utxo.md
+++ b/content/en/platform/corda/5.1/deploying-operating/config/fields/ledger-utxo.md
@@ -10,4 +10,4 @@ menu:
 section_menu: corda51
 ---
 # corda.ledger.utxo
-{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.0/data/config-schema/src/main/resources/net/corda/schema/configuration/ledger.utxo/1.0/corda.ledger.utxo.json" >}}
+{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.1/data/config-schema/src/main/resources/net/corda/schema/configuration/ledger.utxo/1.0/corda.ledger.utxo.json" >}}

--- a/content/en/platform/corda/5.1/deploying-operating/config/fields/membership.md
+++ b/content/en/platform/corda/5.1/deploying-operating/config/fields/membership.md
@@ -10,4 +10,4 @@ menu:
 section_menu: corda51
 ---
 # corda.membership
-{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.0/data/config-schema/src/main/resources/net/corda/schema/configuration/membership/1.0/corda.membership.json" >}}
+{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.1/data/config-schema/src/main/resources/net/corda/schema/configuration/membership/1.0/corda.membership.json" >}}

--- a/content/en/platform/corda/5.1/deploying-operating/config/fields/messaging.md
+++ b/content/en/platform/corda/5.1/deploying-operating/config/fields/messaging.md
@@ -10,4 +10,4 @@ menu:
 section_menu: corda51
 ---
 # corda.messaging
-{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.0/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/corda.messaging.json" >}}
+{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.1/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/corda.messaging.json" >}}

--- a/content/en/platform/corda/5.1/deploying-operating/config/fields/p2p-LinkManager.md
+++ b/content/en/platform/corda/5.1/deploying-operating/config/fields/p2p-LinkManager.md
@@ -10,4 +10,4 @@ menu:
 section_menu: corda51
 ---
 # corda.p2p.linkmanager
-{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.0/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.linkManager/1.0/corda.p2p.linkManager.json" >}}
+{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.1/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.linkManager/1.0/corda.p2p.linkManager.json" >}}

--- a/content/en/platform/corda/5.1/deploying-operating/config/fields/p2p-gateway.md
+++ b/content/en/platform/corda/5.1/deploying-operating/config/fields/p2p-gateway.md
@@ -10,4 +10,4 @@ menu:
 section_menu: corda51
 ---
 # corda.p2p.gateway
-{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.0/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.gateway/1.0/corda.p2p.gateway.json" >}}
+{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.1/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.gateway/1.0/corda.p2p.gateway.json" >}}

--- a/content/en/platform/corda/5.1/deploying-operating/config/fields/reconciliation.md
+++ b/content/en/platform/corda/5.1/deploying-operating/config/fields/reconciliation.md
@@ -10,4 +10,4 @@ menu:
 section_menu: corda51
 ---
 # corda.reconciliation
-{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.0/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json" >}}
+{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.1/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json" >}}

--- a/content/en/platform/corda/5.1/deploying-operating/config/fields/rest.md
+++ b/content/en/platform/corda/5.1/deploying-operating/config/fields/rest.md
@@ -10,4 +10,4 @@ menu:
 section_menu: corda51
 ---
 # corda.rest
-{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.0/data/config-schema/src/main/resources/net/corda/schema/configuration/rest/1.0/corda.rest.json" >}}
+{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.1/data/config-schema/src/main/resources/net/corda/schema/configuration/rest/1.0/corda.rest.json" >}}

--- a/content/en/platform/corda/5.1/deploying-operating/config/fields/sandbox.md
+++ b/content/en/platform/corda/5.1/deploying-operating/config/fields/sandbox.md
@@ -10,4 +10,4 @@ menu:
 section_menu: corda51
 ---
 # corda.sandbox
-{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.0/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json" >}}
+{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.1/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json" >}}

--- a/content/en/platform/corda/5.1/deploying-operating/config/fields/secrets.md
+++ b/content/en/platform/corda/5.1/deploying-operating/config/fields/secrets.md
@@ -11,4 +11,4 @@ section_menu: corda51
 draft: "true"
 ---
 # corda.secrets
-{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.0/data/config-schema/src/main/resources/net/corda/schema/configuration/secrets/1.0/corda.secrets.json" >}}
+{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.1/data/config-schema/src/main/resources/net/corda/schema/configuration/secrets/1.0/corda.secrets.json" >}}

--- a/content/en/platform/corda/5.1/deploying-operating/config/fields/security.md
+++ b/content/en/platform/corda/5.1/deploying-operating/config/fields/security.md
@@ -10,6 +10,6 @@ menu:
 section_menu: corda51
 ---
 # corda.security
-{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.0/data/config-schema/src/main/resources/net/corda/schema/configuration/security/1.0/corda.security.json" >}}
+{{< generate-ref-docs url="https://raw.githubusercontent.com/corda/corda-api/release/os/5.1/data/config-schema/src/main/resources/net/corda/schema/configuration/security/1.0/corda.security.json" >}}
 
 For more information, see the [Security Policies]({{< relref "../security-policies.md" >}}) section.

--- a/content/en/platform/corda/5.1/reference/rest-api/openapi.html
+++ b/content/en/platform/corda/5.1/reference/rest-api/openapi.html
@@ -24,7 +24,7 @@
     <!--
     Redoc element with link to your OpenAPI definition
     -->
-    <redoc spec-url="https://raw.githubusercontent.com/corda/corda-runtime-os/release/os/5.0/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json"></redoc>    <!--
+    <redoc spec-url="https://raw.githubusercontent.com/corda/corda-runtime-os/release/os/5.1/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_1.json"></redoc>    <!--
     Link to Redoc JavaScript on CDN for rendering standalone element
     -->
     <!--<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>    -->


### PR DESCRIPTION
Preview: https://corda5.preview.docs.r3.com/en/platform/corda/5.1.html