### PR TITLE
Make API Cert name singular

### DIFF
--- a/content/en/platform/corda/5.1/developing-applications/packaging/code-signing/custom-cert.md
+++ b/content/en/platform/corda/5.1/developing-applications/packaging/code-signing/custom-cert.md
@@ -18,9 +18,9 @@ However, you can configure the plugin to use a custom certificate using the `cor
 
 {{< note >}}
 When a custom certificate is used, it will need to be uploaded to the cluster using the
-[/api/v1/certificates/cluster/code-signer API endpoint](../../../reference/rest-api/openapi.html#tag/Certificates-API/operation/put_certificates_cluster__usage_).
+[/api/v1/certificate/cluster/code-signer API endpoint](../../../reference/rest-api/openapi.html#tag/Certificate-API/operation/put_certificate_cluster__usage_).
 For example:
-`curl -k -u admin:admin -X PUT -F alias="your-key" -F certificate=@your-key.pem https://localhost:8888/api/v1/certificates/cluster/code-signer`
+`curl -k -u admin:admin -X PUT -F alias="your-key" -F certificate=@your-key.pem https://localhost:8888/api/v1/certificate/cluster/code-signer`
 {{< /note >}}
 
 ```


### PR DESCRIPTION
Preview here: https://corda5.preview.docs.r3.com/en/platform/corda/5.1/developing-applications/packaging/code-signing/custom-cert.html