### PR TITLE
Update how the shortcodes check if a config value is defined..

### DIFF
--- a/layouts/partials/defs-field-desc-ref-docs.html
+++ b/layouts/partials/defs-field-desc-ref-docs.html
@@ -5,10 +5,10 @@
     {{ range $key, $value := $defmap }}
         {{ if eq $key $def}}
                 {{ range $key2, $value2 := $value.anyOf }}
-                    {{ with $value2.minimum }}
+                    {{ if isset $value2 "minimum" }}
                         <br>Minimum value: {{ string ($value2.minimum) }}
                     {{ end }}
-                    {{ with $value2.maximum }}
+                    {{ if isset $value2 "maximum" }}
                         <br>Maximum value: {{ string ($value2.maximum) }}
                     {{ end }}
                 {{ end }}

--- a/layouts/partials/field-desc-ref-docs.html
+++ b/layouts/partials/field-desc-ref-docs.html
@@ -22,13 +22,13 @@
         {{ end }}
     </ul>
 {{ end }}
-{{ with $value.minimum }}
+{{ if isset $value "minimum" }}
     <br>Minimum value: {{ string ($value.minimum) }}
 {{ end }}
-{{ with $value.maximum }}
+{{ if isset $value "maximum" }}
     <br>Maximum value: {{ string ($value.maximum) }}
 {{ end }}
-{{ with $value.default }}
+{{ if isset $value "default" }}
     {{ if eq $value.type "array" }}
         {{ range $arrayvalue := $value.default }}
             {{ if not (reflect.IsMap $arrayvalue)}}

--- a/layouts/partials/referenced-field-desc-ref-docs.html
+++ b/layouts/partials/referenced-field-desc-ref-docs.html
@@ -13,13 +13,13 @@
                     {{ end }}
                 </ul>
             {{ end }}
-            {{ with $value.minimum }}
+            {{ if isset $value "minimum" }}
                 <br>Minimum value: {{ string ($value.minimum) }}.
             {{ end }}
-            {{ with $value.maximum }}
+            {{ if isset $value "maximum" }}
                 <br>Maximum value: {{ string ($value.maximum) }}.
             {{ end }}
-            {{ with $value.default }}
+            {{ if isset $value "default" }}
                 <br>Default value: {{ string ($value.default) }}.
             {{ end }}
         </li>


### PR DESCRIPTION
.. Previously, 0 values were not rendered in the docs.

For example:

![image](https://github.com/corda/corda-docs-portal/assets/103633799/25e9378d-23a1-42da-adcf-90dece058e8b)

Before:

![image](https://github.com/corda/corda-docs-portal/assets/103633799/849e44b6-6b08-4f18-ad34-9391059e5883)

After: (https://nadine.preview.docs.r3.com/en/platform/corda/5.0/deploying-operating/config/fields/messaging.html)

![image](https://github.com/corda/corda-docs-portal/assets/103633799/b0c09c56-b028-491b-9a83-c82b05d551ba)

