### PR TITLE
Update glossary tooltip to default to latest version (5.1)

### DIFF
--- a/themes/doks/layouts/shortcodes/tooltip.html
+++ b/themes/doks/layouts/shortcodes/tooltip.html
@@ -46,7 +46,7 @@
 {{ $searchtermlower := lower .Inner }}
 {{ $searchtermkebab := replace $searchtermlower " " "-" }}
 {{- /* If no version set for file, point to glossary of latest C5 version. For example, "about the docs" */}}    
-{{ $versionfolder := "corda/5.0" }}
+{{ $versionfolder := "corda/5.1" }}
 {{ $version := string (.Page.Params.version) }}
 {{ with $version }}
     {{ $versionfolder := replace (lower ($version)) " " "/" }}


### PR DESCRIPTION
Preview: https://nadine.preview.docs.r3.com/