### PR TITLE
DOC-6024: Moved UTXO Ledger to the end of the metrics list

### DIFF
--- a/content/en/platform/corda/5.1/deploying-operating/observability/metrics/ledger.md
+++ b/content/en/platform/corda/5.1/deploying-operating/observability/metrics/ledger.md
@@ -6,7 +6,7 @@ menu:
   corda51:
     parent: corda51-cluster-metrics
     identifier: corda51-cluster-ledger
-    weight: 900
+    weight: 1600
 section_menu: corda51
 ---
 


### PR DESCRIPTION
Metrics are sorted alphabetically now. Moved UTXO Ledger to the end of the metrics list.