### PR TITLE
Update how hyperlinks for glossary terms are generated

### DIFF
--- a/themes/doks/layouts/shortcodes/tooltip.html
+++ b/themes/doks/layouts/shortcodes/tooltip.html
@@ -43,8 +43,10 @@
 
 </style>
 
-{{ $searchtermlower := lower .Inner }}
+{{ $searchterm := .Inner }}
+{{ $searchtermlower := lower $searchterm }}
 {{ $searchtermkebab := replace $searchtermlower " " "-" }}
+
 {{- /* If no version set for file, point to glossary of latest C5 version. For example, "about the docs" and tools */}}    
 {{ $versionfolder := "corda/5.0" }}
 {{ $version := string (.Page.Params.version) }}
@@ -54,16 +56,20 @@
     {{ end }}
 {{ end }}
 
-{{ $termlink := printf "%s" $searchtermkebab | printf "%s%s" "/reference/glossary.html#"  | printf "%s%s" $versionfolder | printf "%s%s" "en/platform/" | printf "%s%s" .Site.BaseURL | safeURL }}
 {{ $file := printf "%s" "/glossaryitems.json" | printf "%s%s" $versionfolder | printf "%s%s" "content/en/platform/" }}
-<a class="term" href ='{{ $termlink }}' >&nbsp{{ .Inner }}
+
+{{ $termlink := printf "%s" "/reference/glossary.html#"  | printf "%s%s" $versionfolder | printf "%s%s" "en/platform/" | printf "%s%s" .Site.BaseURL | safeURL }}
 
 {{ $glossarylist := getJSON $file }}
 {{ range $term, $value := $glossarylist }}
     {{ $term := lower $term }}
     {{ if eq $term $searchtermlower }} 
+        {{ $termlink := printf "%s" $searchtermkebab | printf "%s%s" $termlink }}
+        <a class="term" href ='{{ $termlink }}' >&nbsp{{ $searchterm }}
         <span class="definition" >{{ $value.definition }}</span>
     {{ else if eq $term (strings.TrimSuffix "s" $searchtermlower) }}
+        {{ $termlink := printf "%s" (strings.TrimSuffix "s" $searchtermkebab) | printf "%s%s" $termlink | printf "%s" }}
+        <a class="term" href ='{{ $termlink }}' >&nbsp{{ $searchterm }}
         <span class="definition">{{ $value.definition }}</span>
     {{ end }}
 {{ end }}


### PR DESCRIPTION
Fix for hyperlinks on plural versions of glossary terms. For example, the glossary items in this section: https://docs.r3.com/en/platform/corda/5.0/key-concepts/cluster-admin/workers.html#workers

Preview: https://nadine.preview.docs.r3.com/en/platform/corda/5.0/key-concepts/cluster-admin/workers.html#workers