### PR TITLE
Enable git variables

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -22,7 +22,7 @@ pygmentsUseClasses = false
 pygmentsStyle = "emacs"
 
 # See https://gohugo.io/variables/git/
-enableGitInfo = false
+enableGitInfo = true
 
 # See https://gohugo.io/getting-started/configuration-markup#highlight
 [markup]

--- a/themes/doks/config/_default/config.toml
+++ b/themes/doks/config/_default/config.toml
@@ -3,7 +3,6 @@ canonifyURLs = false
 disableAliases = true
 disableHugoGeneratorInject = true
 enableEmoji = true
-enableGitInfo = false
 enableRobotsTXT = true
 languageCode = "en-US"
 paginate = 7


### PR DESCRIPTION
Hugo can use git variables to give an accurate date modified for each page. 

Preview: https://neil.preview.docs.r3.com/

For example:

![image](https://github.com/corda/corda-docs-portal/assets/103633799/a518f3d0-7f29-41dc-b0ec-1cc73cc9e654)

Page source for https://docs.r3.com/en/platform/corda/5.0.html:

![image](https://github.com/corda/corda-docs-portal/assets/103633799/ee60fb20-6da8-4a0e-9b3f-7cbf7fbaf6b7)

Page source for https://neil.preview.docs.r3.com/en/platform/corda/5.0.html:

![image](https://github.com/corda/corda-docs-portal/assets/103633799/cd37a001-ab4e-44e4-a91c-657a78c7d125)
