### PR TITLE
Correct margin for paragraphs inside lists

### DIFF
--- a/themes/doks/assets/scss/common/_global.scss
+++ b/themes/doks/assets/scss/common/_global.scss
@@ -463,3 +463,7 @@ summary::after {
 details[open] summary:after {
   content: url("/icons/icon-arrow-up.svg");
 }
+
+li p{
+  margin-bottom: 0;
+};


### PR DESCRIPTION
Before:

![image](https://github.com/corda/corda-docs-portal/assets/103633799/159c0b27-718f-4a66-b79e-6b117c6fba1f)

After:

![image](https://github.com/corda/corda-docs-portal/assets/103633799/56de11f4-10fb-4edf-ac58-2af630a4f70d)


Before:

![image](https://github.com/corda/corda-docs-portal/assets/103633799/52761ba6-7f5e-4121-bc5c-3096e7675374)

After:

![image](https://github.com/corda/corda-docs-portal/assets/103633799/9a791589-8592-4e65-9d16-6ee64959dbc9)

Preview: https://colin.preview.docs.r3.com/ **To be reviewed by all team members to ensure that the change is as expected on all pages.**