### PR TITLE
Filter Corda Metrics in Prometheus through the Pod Monitor

### DIFF
--- a/content/en/platform/corda/5.1/deploying-operating/observability/metrics/_index.md
+++ b/content/en/platform/corda/5.1/deploying-operating/observability/metrics/_index.md
@@ -35,11 +35,7 @@ You can disable these annotations by providing the following overrides on the Co
 metrics:
     scrape: false
 ```
-If you are using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator),
-the Corda Helm chart supports the creation of a PodMonitor custom resource.
-The PodMonitor should be configured with the labels that the Prometheus Operator is set to discover.
-When using the [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-Helm chart, this is the name of the Helm release for the Prometheus stack. For example:
+If you are using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), the Corda Helm chart supports the creation of a PodMonitor custom resource. You should configure the PodMonitor with the labels that the Prometheus Operator is set to discover. When using the [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) Helm chart, this is the name of the Helm release for the Prometheus stack. For example:
 
 ```yaml
 metrics:
@@ -48,6 +44,27 @@ metrics:
     labels:
       release: [RELEASE_NAME]
 ```
+
+You can also configure filters in the PodMonitor to reduce the metrics recorded using the following fields:
+
+* `keepNames` — a list of regular expressions for the names of metrics that Prometheus records. If empty, all metrics are recorded. Prometheus records the following metrics by default:
+  * corda_flow_execution_time_seconds_(count|sum|max)
+  * corda_http_server_request_time_seconds_(count|sum|max)
+  * corda_p2p_gateway_inbound_request_time_seconds_(count|sum|max)
+  * corda_p2p_gateway_outbound_request_time_seconds_(count|sum|max)
+  * corda_p2p_gateway_outbound_tls_connections_total
+  * corda_p2p_message_outbound_total
+  * corda_p2p_message_outbound_replayed_total
+  * corda_p2p_message_outbound_latency_seconds_(count|sum|max)
+  * corda_p2p_message_inbound_total
+  * corda_p2p_session_outbound_total
+  * corda_p2p_session_inbound_total
+  * corda_membership_actions_handler_time_seconds_(count|sum|max)
+  * jvm_.*
+  * process_cpu_usag
+* `dropLabels` — a list of regular expressions for labels that Prometheus drops for all metrics. If empty, all labels are recorded. Prometheus drops the following metrics by default:
+  * virtualnode_destination
+  * virtualnode_source
 
 ### Exported Metrics
 

--- a/content/en/platform/corda/5.1/deploying-operating/observability/metrics/_index.md
+++ b/content/en/platform/corda/5.1/deploying-operating/observability/metrics/_index.md
@@ -45,9 +45,9 @@ metrics:
       release: [RELEASE_NAME]
 ```
 
-You can also configure filters in the PodMonitor to reduce the metrics recorded using the following fields:
+You can also configure filters in the PodMonitor to reduce the metrics recorded by setting the following fields:
 
-* `keepNames` — a list of regular expressions for the names of metrics that Prometheus records. If empty, all metrics are recorded. Prometheus records the following metrics by default:
+* `keepNames` — a list of regular expressions for the names of the metrics that Prometheus records. If empty, all metrics are recorded. Prometheus records the following metrics by default:
   * corda_flow_execution_time_seconds_(count|sum|max)
   * corda_http_server_request_time_seconds_(count|sum|max)
   * corda_p2p_gateway_inbound_request_time_seconds_(count|sum|max)
@@ -62,7 +62,7 @@ You can also configure filters in the PodMonitor to reduce the metrics recorded 
   * corda_membership_actions_handler_time_seconds_(count|sum|max)
   * jvm_.*
   * process_cpu_usag
-* `dropLabels` — a list of regular expressions for labels that Prometheus drops for all metrics. If empty, all labels are recorded. Prometheus drops the following metrics by default:
+* `dropLabels` — a list of regular expressions for the labels that Prometheus drops for all metrics. If empty, all labels are recorded. Prometheus drops the following metrics by default:
   * virtualnode_destination
   * virtualnode_source
 

--- a/content/en/platform/corda/5.1/deploying-operating/observability/metrics/_index.md
+++ b/content/en/platform/corda/5.1/deploying-operating/observability/metrics/_index.md
@@ -61,7 +61,7 @@ You can also configure filters in the PodMonitor to reduce the metrics recorded 
   * corda_p2p_session_inbound_total
   * corda_membership_actions_handler_time_seconds_(count|sum|max)
   * jvm_.*
-  * process_cpu_usag
+  * process_cpu_usage
 * `dropLabels` — a list of regular expressions for the labels that Prometheus drops for all metrics. If empty, all labels are recorded. Prometheus drops the following metrics by default:
   * virtualnode_destination
   * virtualnode_source


### PR DESCRIPTION
Preview: https://colin.preview.docs.r3.com/en/platform/corda/5.1/deploying-operating/observability/metrics.html