### PR TITLE
Update JSON config shortcode to use different formatting when default value is for a set of values

### DIFF
--- a/layouts/partials/field-desc-ref-docs.html
+++ b/layouts/partials/field-desc-ref-docs.html
@@ -6,29 +6,33 @@
 {{ with $value.description}} 
     - {{ $value.description}} 
 {{ end }}    
-{{ with $value.oneOf }}
+{{ if or (isset $value "oneOf") (isset $value "enum") }}
     This must be set to one of the following values:
     <ul>
+    {{ with $value.oneOf }}
         {{ range $oneOfk, $oneOfv := $value.oneOf }}
-                <li>{{ $oneOfv.const }} - {{ $oneOfv.title }}</li>
+            <li>{{ $oneOfv.const }} - {{ $oneOfv.title }}</li>
         {{ end }}
-    </ul>
-{{ end }}
-{{ with $value.enum }}
-    This must be set to one of the following values:
-    <ul>
+    {{ end }}
+    {{ with $value.enum }}
         {{ range $enumval := $value.enum }}
             <li>{{ $enumval }}</li>
         {{ end }}
+    {{ end }}
     </ul>
-{{ end }}
-{{ if isset $value "minimum" }}
-    <br>Minimum value: {{ string ($value.minimum) }}
-{{ end }}
-{{ if isset $value "maximum" }}
-    <br>Maximum value: {{ string ($value.maximum) }}
-{{ end }}
-{{ if isset $value "default" }}
+    {{ if (isset $value "default") }}
+        {{ if eq $value.type "array" }}
+            {{ range $arrayvalue := $value.default }}
+                {{ if not (reflect.IsMap $arrayvalue)}}
+                    Default value: {{ $arrayvalue }}
+                {{ end }}
+            {{ end }}
+        {{ else if not (reflect.IsMap $value.default) }}
+            Default value: {{ string ($value.default) }} 
+        {{ end }}
+    {{ end }}
+    
+{{ else if (isset $value "default") }}
     {{ if eq $value.type "array" }}
         {{ range $arrayvalue := $value.default }}
             {{ if not (reflect.IsMap $arrayvalue)}}
@@ -38,6 +42,12 @@
     {{ else if not (reflect.IsMap $value.default) }}
         <br>Default value: {{ string ($value.default) }} 
     {{ end }}
+{{ end }}
+{{ if isset $value "minimum" }}
+    <br>Minimum value: {{ string ($value.minimum) }}
+{{ end }}
+{{ if isset $value "maximum" }}
+    <br>Maximum value: {{ string ($value.maximum) }}
 {{ end }}
 {{ $ref := index $value "$ref"}}
 {{ with $ref }}


### PR DESCRIPTION
Before:

![image](https://github.com/corda/corda-docs-portal/assets/103633799/2b9e9967-3407-453c-bc50-4294e2e10798)

Preview: https://nadine.preview.docs.r3.com/en/platform/corda/5.1/deploying-operating/config/fields/p2p-gateway.html