### PR TITLE
article:published_time

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -94,3 +94,6 @@ googleTagManagerID = "G-NCYRYSGJ7C"
     source = 'content/en'
     target = 'content/en'
     excludeFiles = ['interop-raw/**']
+
+[frontmatter]
+publishDate = [':git']

--- a/themes/doks/layouts/partials/head/opengraph.html
+++ b/themes/doks/layouts/partials/head/opengraph.html
@@ -28,7 +28,7 @@
 {{ end -}}
 
 {{ $iso8601 := "2006-01-02T15:04:05-07:00" -}}
-{{ if .IsPage -}}
+{{ if or .IsPage .IsSection -}}
   {{ if not .PublishDate.IsZero -}}
     <meta property="article:published_time" {{ .PublishDate.Format $iso8601 | printf "content=%q" | safeHTMLAttr }}>
   {{ else if not .Date.IsZero -}}


### PR DESCRIPTION
Configure Hugo to set `article:published_time` to the last modified date from Git and include this in the `<head>` of section and child pages.

Preview: https://nadine.preview.docs.r3.com/