### PR TITLE
Remove summary from Open Graph description

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -9,8 +9,8 @@ description = "Find tutorials, sample code, developer guides, and API references
 
 ## Open Graph + Twitter Cards
 images = ["r3-docs-open-graph.png"]
-twitterSite = "cordablockchain"
-twitterCreator = "cordablockchain"
+twitterSite = "inside_r3"
+twitterCreator = "inside_r3"
 facebookAuthor = "R3blockchain"
 facebookPublisher = "R3blockchain"
 ogLocale = "en_US"
@@ -18,7 +18,7 @@ ogLocale = "en_US"
 ## JSON-LD
 schemaType = "Organization"
 schemaLogo = "logo-r3.png"
-schemaTwitter = "https://twitter.com/cordablockchain"
+schemaTwitter = "https://twitter.com/inside_r3"
 schemaLinkedIn = "https://www.linkedin.com/company/r3cev-llc/"
 schemaGitHub = "https://github.com/corda"
 schemaSection = "blog"

--- a/themes/doks/layouts/partials/head/opengraph.html
+++ b/themes/doks/layouts/partials/head/opengraph.html
@@ -1,5 +1,5 @@
 <meta property="og:title" content="{{ with .Params.Version }}{{ if eq . $.Title}}{{ $.Title }}{{ else }}{{ $.Title }} - {{ . }}{{ end }}{{ else }}{{ $.Title }}{{ end }}">
-<meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}">
+<meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}">
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}">
 {{ if $.Scratch.Get "paginator" -}}
   {{ $paginator := .Paginate (where .Site.RegularPages.ByDate.Reverse "Section" "blog" ) -}}

--- a/themes/doks/layouts/partials/head/twitter_cards.html
+++ b/themes/doks/layouts/partials/head/twitter_cards.html
@@ -17,7 +17,7 @@
 {{ end -}}
 
 <meta name="twitter:title" content="{{ with .Params.Version }}{{ if eq . $.Title}}{{ $.Title }}{{ else }}{{ $.Title }} - {{ . }}{{ end }}{{ else }}{{ $.Title }}{{ end }}">
-<meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}">
+<meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}">
 {{ with .Site.Social.twitter -}}
   <meta name="twitter:site" content="@{{ . }}">
 {{ end -}}


### PR DESCRIPTION
- Removed summary from Open Graph descriptions. This is often badly formatted and not fit for purpose.
- Also, updated the Twitter account.
Preview: https://nadine.preview.docs.r3.com/