### PR TITLE
Code homepage links to point to latest C5 version

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -1,5 +1,5 @@
-# Version
-corda5versions = ["Corda 5.0", "Corda 5.1"]
+# Versions. The latest Corda 5 release must be first in the list.
+corda5versions = ["Corda 5.1", "Corda 5.0"]
 
 ## Homepage
 title = "R3 Documentation"

--- a/themes/doks/layouts/index.html
+++ b/themes/doks/layouts/index.html
@@ -31,7 +31,7 @@
           <div class="card h-100">
             <div class="card-body">
               <h3 class="card-title">Get Started</h3>
-              <p>Learn <a href="/en/platform/corda/4.11/community/key-concepts.html" class="fw-semibold">Corda 4</a> or <a href="/en/platform/corda/5.0/key-concepts.html" class="fw-semibold">Corda 5</a> key concepts.</p>
+              <p>Learn <a href="/en/platform/corda/4.11/community/key-concepts.html" class="fw-semibold">Corda 4</a> or <a href="/en/platform/corda/{{ replace (index .Site.Params.corda5versions 0) "Corda " "" }}/key-concepts.html" class="fw-semibold">Corda 5</a> key concepts.</p>
             </div>
           </div>
         </div>
@@ -42,7 +42,7 @@
               <p>Everything that CorDapp Developers, Cluster Administrators, and Network Operators need to know about the next-generation of Corda.</p>
             </div>
             <div class="card-footer">
-              <a href="en/platform/corda/5.1.html" class="btn rounded stretched-link">Start Exploring</a>
+              <a href="en/platform/corda/{{ replace (index .Site.Params.corda5versions 0) "Corda " "" }}.html" class="btn rounded stretched-link">Start Exploring</a>
             </div>
           </div>
         </div>

--- a/themes/doks/layouts/shortcodes/tooltip.html
+++ b/themes/doks/layouts/shortcodes/tooltip.html
@@ -48,7 +48,7 @@
 {{ $searchtermkebab := replace $searchtermlower " " "-" }}
 
 {{- /* If no version set for file, point to glossary of latest C5 version. For example, "about the docs" and tools */}}    
-{{ $versionfolder := "corda/5.1" }}
+{{ $versionfolder := replace (index .Site.Params.corda5versions 0) "Corda " "corda/" }}
 {{ $version := string (.Page.Params.version) }}
 {{ with $version }}
     {{ if ne $version "tools" }}


### PR DESCRIPTION
The Corda 5 Key Concepts link on the homepage was still pointing to 5.0. Updated the code to always use the newest version.

Preview: https://nadine.preview.docs.r3.com/