### PR TITLE
Make spacing around code blocks inside lists consistent with other content

### DIFF
--- a/themes/doks/assets/scss/common/_global.scss
+++ b/themes/doks/assets/scss/common/_global.scss
@@ -464,7 +464,10 @@ details[open] summary:after {
   content: url("/icons/icon-arrow-up.svg");
 }
 
+
+
 li p{
+  margin-top: 0.5rem;
   margin-bottom: 0;
 }
 
@@ -473,5 +476,10 @@ li .nav-tabs{
 }
 
 li .tab-content{
+  margin-bottom: 0.5rem;
+}
+
+li pre{
+  margin-top: 0.5rem;
   margin-bottom: 0.5rem;
 };

--- a/themes/doks/assets/scss/common/_global.scss
+++ b/themes/doks/assets/scss/common/_global.scss
@@ -468,10 +468,10 @@ li p{
   margin-bottom: 0;
 }
 
-li nav-tab{
+li .nav-tabs{
   margin-top: 0.5rem;
 }
 
-li nav-tab-content{
+li .tab-content{
   margin-bottom: 0.5rem;
 };

--- a/themes/doks/assets/scss/common/_global.scss
+++ b/themes/doks/assets/scss/common/_global.scss
@@ -475,4 +475,8 @@ li .tab-content{
 li pre{
   margin-top: 1rem;
   margin-bottom: 1rem;
+}
+
+li ul{
+  margin-bottom: 1rem;
 };

--- a/themes/doks/assets/scss/common/_global.scss
+++ b/themes/doks/assets/scss/common/_global.scss
@@ -464,22 +464,15 @@ details[open] summary:after {
   content: url("/icons/icon-arrow-up.svg");
 }
 
-
-
-li p{
-  margin-top: 0.5rem;
-  margin-bottom: 0;
-}
-
 li .nav-tabs{
-  margin-top: 0.5rem;
+  margin-top: 1rem;
 }
 
 li .tab-content{
-  margin-bottom: 0.5rem;
+  margin-bottom: 1rem;
 }
 
 li pre{
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
 };

--- a/themes/doks/assets/scss/common/_global.scss
+++ b/themes/doks/assets/scss/common/_global.scss
@@ -466,4 +466,12 @@ details[open] summary:after {
 
 li p{
   margin-bottom: 0;
+}
+
+li nav-tab{
+  margin-top: 0.5rem;
+}
+
+li nav-tab-content{
+  margin-bottom: 0.5rem;
 };


### PR DESCRIPTION
The space between code blocks was too great. When this was reduced, lists looked too squashed so consistently increased all spacing within list items.

**Example 1**

Before:
![image](https://github.com/corda/corda-docs-portal/assets/103633799/f9957a71-6eb1-4ca8-b3a6-6b8f4c6103bc)

After:
![image](https://github.com/corda/corda-docs-portal/assets/103633799/a49d2ec3-47d2-47e7-94c9-e68d74245fa7)

Preview: 
https://neil.preview.docs.r3.com/en/platform/corda/5.1/application-networks/creating/mgm/cpi.html

**Example 2**

Before:
![image](https://github.com/corda/corda-docs-portal/assets/103633799/017c539c-9d3b-4a83-8271-9258f24306a7)

After:
![image](https://github.com/corda/corda-docs-portal/assets/103633799/dc20086a-cc7e-418d-8686-98363866c8e8)

Preview: 
https://neil.preview.docs.r3.com/en/platform/corda/5.1/deploying-operating/deployment/deploying.html#container-images-for-corda