### PR TITLE
Code Block Improvements

### DIFF
--- a/themes/doks/assets/scss/components/_code.scss
+++ b/themes/doks/assets/scss/components/_code.scss
@@ -52,7 +52,39 @@ pre {
     padding: 1.25rem 1.5rem;
     tab-size: 4;
     scrollbar-width: thin;
-    scrollbar-color: transparent transparent;
+    scrollbar-color: $gray-200 transparent;
+  }
+}
+
+.copy-code {
+  display: none;
+  position: absolute;
+  right: 0.5rem;
+  top: 0.4rem;
+  z-index: 20000000;
+
+  button {
+    border: none;
+    font-size: $font-size-xs;
+    border-radius: 5px;
+    background-color: #7A7A7A;
+    padding-left: 0.6rem;
+
+    &::before {
+      content: url("/icons/copy.svg");
+      width: 0.8rem;
+      top: 3px;
+      left: -0.2rem;
+      position: relative;
+    }
+
+    &:hover {
+      color: $white;
+
+      &::before {
+        content: url("/icons/copy-white.svg");
+      }
+    }
   }
 }
 
@@ -76,36 +108,9 @@ pre {
 
 .highlight {
   position: relative;
+  
 
-  .copy-code {
-    position: absolute;
-    right: 0.5rem;
-    top: 0.4rem;
 
-    button {
-      border: none;
-      font-size: $font-size-xs;
-      border-radius: 5px;
-      background-color: #7A7A7A;
-      padding-left: 0.6rem;
-
-      &::before {
-        content: url("/icons/copy.svg");
-        width: 0.8rem;
-        top: 3px;
-        left: -0.2rem;
-        position: relative;
-      }
-
-      &:hover {
-        color: $white;
-
-        &::before {
-          content: url("/icons/copy-white.svg");
-        }
-      }
-    }
-  }
 }
 
 .hljs {
@@ -147,13 +152,8 @@ pre code::-webkit-scrollbar-thumb {
   background: $gray-200;
 }
 
-pre code:hover {
-  scrollbar-width: thin;
-  scrollbar-color: $gray-200 transparent;
-}
-
-pre code::-webkit-scrollbar-thumb:hover {
-  background: $gray-200;
+.highlight:hover .copy-code{
+  display: block;
 }
 
 .hljs-type,

--- a/themes/doks/assets/scss/components/_code.scss
+++ b/themes/doks/assets/scss/components/_code.scss
@@ -61,7 +61,6 @@ pre {
   position: absolute;
   right: 0.5rem;
   top: 0.4rem;
-  z-index: 20000000;
 
   button {
     border: none;
@@ -108,9 +107,6 @@ pre {
 
 .highlight {
   position: relative;
-  
-
-
 }
 
 .hljs {


### PR DESCRIPTION
- Copy button now only displays on hover. This button was hiding code text previously.
- Scrollbar for long lines of code is now always displayed. Previously, this was only displayed on hover meaning users might not realise there was more code not displayed.

Preview: https://colin.preview.docs.r3.com/