### PR TITLE
Update copyright year and fix footer on 404

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -36,9 +36,6 @@ landscapePhotoWidths = [900, 800, 700, 600, 500]
 portraitPhotoWidths = [800, 700, 600, 500]
 lqipWidth = "20x"
 
-# Footer
-footer = "&copy; 2023 R3, All Rights Reserved"
-
 # Alert
 alert = false
 alertText = "Like Doks? <a class=\"alert-link\" href=\"https://github.com/h-enk/doks/stargazers\">Star on GitHub</a>. Thanks!</a>"

--- a/themes/doks/layouts/404.html
+++ b/themes/doks/layouts/404.html
@@ -1,10 +1,8 @@
 {{ define "main" }}
-<div class="row justify-content-center">
-  <div class="col-md-12 col-lg-10 col-xl-8">
-    <article>
-      <h1 class="text-center">Page not found :(</h1>
-      <p class="text-center">The page you are looking for doesn't exist or has been moved.</p>
-    </article>
-  </div>
-</div>
+	<div class="row justify-content-center">
+		<main class="docs-content col-md-12 col-lg-10 col-xl-8">
+			<h1 class="text-center">Page not found :(</h1>
+		    <p class="text-center">The page you are looking for doesn't exist or has been moved. Try using search to find what you're looking for or return <a href={{ .Site.BaseURL | absURL }}>home</a>.</p>
+		</main>
+	</div>
 {{ end }}

--- a/themes/doks/layouts/partials/footer/footer.html
+++ b/themes/doks/layouts/partials/footer/footer.html
@@ -29,7 +29,7 @@
         <div class="row">
           <div class="col-lg-6 text-lg-start mt-2 mt-lg-0">
             <ul class="list-inline">
-              <li class="list-inline-item">{{ .Site.Params.footer | safeHTML }}</li>
+              <li class="list-inline-item">&copy; {{ now.Year }} R3, All Rights Reserved</li>
             </ul>
           </div>
           <div class="col-lg-10 text-lg-end my-2 my-lg-0">

--- a/themes/doks/layouts/partials/footer/footer.html
+++ b/themes/doks/layouts/partials/footer/footer.html
@@ -12,7 +12,7 @@
                   </ul>
                 </div>
                 <div class="footer-urls">
-                     <ul class="footer-links mb-0">
+                      <ul class="footer-links mb-0">
                       <li><a href="https://community.r3.com/" target="_blank">Community Forum</a></li>
                       <li><a href="https://developer.r3.com/blog" target="_blank">Blog</a></li>
                     </ul>
@@ -29,7 +29,7 @@
         <div class="row">
           <div class="col-lg-6 text-lg-start mt-2 mt-lg-0">
             <ul class="list-inline">
-              <li class="list-inline-item">&copy; {{ now.Year }} R3, All Rights Reserved</li>
+              <li class="list-inline-item">&copy; {{ now.Year | safeHTML }} R3, All Rights Reserved</li>
             </ul>
           </div>
           <div class="col-lg-10 text-lg-end my-2 my-lg-0">


### PR DESCRIPTION
Pushed footer to bottom of 404 page. Preview from local build:
![image](https://github.com/corda/corda-docs-portal/assets/103633799/9c07bd14-dfcf-4fa1-9949-7c347a921ee4)


Also fixed https://r3-cev.atlassian.net/browse/DOC-6334. Updated copyright year to variable so that it is always correct.

Preview: https://amie.preview.docs.r3.com/