### PR TITLE
ES-1938: update Node.js from v14 to v20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM ${REGISTRY}/ubuntu:focal
 
 RUN apt-get update && \
     apt-get install curl git tar gzip unzip jq -y
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 RUN apt-get install -y nodejs
-RUN npm install -g npm@7.0.7
+RUN npm install -g npm@10.4.0
 RUN npm --version
 
 ARG MUFFET_VERSION


### PR DESCRIPTION
* Node.js v14 is not longer supported and an upgrade to the current version (20) is recommended by the project
* also update `npm` to recommended major version (10.4.0)