### PR TITLE
Reduce white space below tables

### DIFF
--- a/themes/doks/assets/scss/components/_tables.scss
+++ b/themes/doks/assets/scss/components/_tables.scss
@@ -2,7 +2,7 @@ table,
 .table {
   @extend .table;
 
-  margin: 1rem 0 3rem 0;
+  margin: 1rem 0 2rem 0;
   font-size: $font-size-sm;
 
   > :not(caption) > * > * {


### PR DESCRIPTION
Preview: https://nadine.preview.docs.r3.com/

Reduced the space below tables (it was greater than the space above headings).

Some examples:

1. 

![image](https://github.com/corda/corda-docs-portal/assets/103633799/cb435c54-e1ad-485a-aa39-87770a6bdee7)

![image](https://github.com/corda/corda-docs-portal/assets/103633799/95cc2c1e-1935-4108-bb30-18b4ce889553)

2.

![image](https://github.com/corda/corda-docs-portal/assets/103633799/41523288-e13f-4c33-b67d-73fcbe13c32f)

![image](https://github.com/corda/corda-docs-portal/assets/103633799/54c5c8c4-24c6-483a-b391-63daa848d312)

3.

![image](https://github.com/corda/corda-docs-portal/assets/103633799/75412e6d-ab99-46d2-b89b-6b2b7d9c08fb)

![image](https://github.com/corda/corda-docs-portal/assets/103633799/cd7ab485-a1c2-4e0a-be82-e7df6be3cd64)

