### PR TITLE
API References Index Page

### DIFF
--- a/content/en/api-ref/_index.md
+++ b/content/en/api-ref/_index.md
@@ -8,6 +8,7 @@ title: API References
 menu:
   api-ref:
     weight: -100
+    identifier: api-ref-index
 ---
 
 ## Corda 5

--- a/content/en/api-ref/_index.md
+++ b/content/en/api-ref/_index.md
@@ -4,10 +4,8 @@ description: "API reference documentation for all versions of Corda"
 section_menu: api-ref
 project: api-ref
 version: 'api-ref'
-title: API Reference
+title: API References
 ---
-
-# API References
 
 ## Corda 5
 

--- a/content/en/api-ref/_index.md
+++ b/content/en/api-ref/_index.md
@@ -7,17 +7,16 @@ version: 'api-ref'
 title: API Reference
 ---
 
+# API References
 
-# API Reference
-
-## Corda 5 API reference
+## Corda 5
 
 See the [{{< latest-c5-version >}}](../../en/api-ref/corda/{{< latest-c5-version >}}/index.html) page to access the API reference documentation for all API modules publicly exposed in {{< latest-c5-version >}}.
 
-## Corda 4 API Reference
+## Corda 4
 
 See the [Corda 4 API reference]({{< relref "api-ref-corda-4.md" >}}) page to access the API reference documentation for all API modules publicly exposed in the Corda 4 releases, including Corda Community and Open Source Edition 4.10 and 4.11, Corda Enterprise 4.7 to 4.11, and Corda Enterprise Network Manager (CENM) 1.0 to 1.6.
 
-## Older Corda API Reference
+## Older Versions of Corda
 
 You can find the API reference documentation for older versions of Corda (1.0, 2.0, and 3.0 to 3.4) and Corda Enterprise (3.0 to 3.3) [directly in the documentation repository](https://github.com/corda/corda-docs-portal/tree/main/content/en/archived-docs/).

--- a/content/en/api-ref/_index.md
+++ b/content/en/api-ref/_index.md
@@ -5,6 +5,9 @@ section_menu: api-ref
 project: api-ref
 version: 'api-ref'
 title: API References
+menu:
+  api-ref:
+    weight: -100
 ---
 
 ## Corda 5

--- a/content/en/api-ref/api-ref-corda-4.md
+++ b/content/en/api-ref/api-ref-corda-4.md
@@ -9,7 +9,7 @@ project: api-ref
 title: Corda 4 API reference
 ---
 
-# Corda 4 API reference
+# Corda 4 API references
 
 This page provides links to the API reference documentation for all API modules publicly exposed in the Corda 4 releases, including Corda Community and Open Source Edition 4.11 and 4.10, Corda Community 4.9, Corda Enterprise 4.5 to 4.10, and Corda Enterprise Network Manager (CENM) 1.0 to 1.5.
 

--- a/content/en/api-ref/api-ref-corda-4.md
+++ b/content/en/api-ref/api-ref-corda-4.md
@@ -2,14 +2,11 @@
 date: '2021-04-24T00:00:00Z'
 menu:
   api-ref:
-    name: Corda 4 API reference
     weight: 1000
     identifier: api-ref-corda-4
 project: api-ref
-title: Corda 4 API reference
+title: Corda 4 API references
 ---
-
-# Corda 4 API references
 
 This page provides links to the API reference documentation for all API modules publicly exposed in the Corda 4 releases, including Corda Community and Open Source Edition 4.11 and 4.10, Corda Community 4.9, Corda Enterprise 4.5 to 4.10, and Corda Enterprise Network Manager (CENM) 1.0 to 1.5.
 

--- a/content/en/api-ref/api-ref-corda-4.md
+++ b/content/en/api-ref/api-ref-corda-4.md
@@ -3,6 +3,7 @@ date: '2021-04-24T00:00:00Z'
 menu:
   api-ref:
     weight: 1000
+    parent: api-ref-index
     identifier: api-ref-corda-4
 project: api-ref
 title: Corda 4 API references


### PR DESCRIPTION
Updates to API index page. Left-hand menu and headings are confusing.

Preview: https://amie.preview.docs.r3.com/en/api-ref.html