### PR TITLE
DOC-6477: Added installing Corda CLI link to CorDapp template prereqs

### DIFF
--- a/content/en/platform/corda/5.2/developing-applications/cordapp-template/prerequisites/_index.md
+++ b/content/en/platform/corda/5.2/developing-applications/cordapp-template/prerequisites/_index.md
@@ -28,7 +28,7 @@ The {{< version >}} CorDapp Template has been tested with the following:
 | Intellij                                 | ~v2021.x.y Community Edition                                        |
 | git                                      | ~v2.24.1                                                            |
 | Docker                                   | Docker Engine ~v20.x.y or Docker Desktop ~v3.5.x                    |
-| {{< tooltip >}}Corda CLI{{< /tooltip >}} | See [Installing the Corda CLI]({{< relref "../../tooling/installing-corda-cli/installing-corda-cli.md" >}}) section. |
+| {{< tooltip >}}Corda CLI{{< /tooltip >}} | See [Installing the Corda CLI]({{< relref "../../tooling/installing-corda-cli.md" >}}) section. |
 
 ## Required CorDapp Template Ports
 

--- a/content/en/platform/corda/5.2/developing-applications/cordapp-template/prerequisites/_index.md
+++ b/content/en/platform/corda/5.2/developing-applications/cordapp-template/prerequisites/_index.md
@@ -28,7 +28,7 @@ The {{< version >}} CorDapp Template has been tested with the following:
 | Intellij                                 | ~v2021.x.y Community Edition                                        |
 | git                                      | ~v2.24.1                                                            |
 | Docker                                   | Docker Engine ~v20.x.y or Docker Desktop ~v3.5.x                    |
-| {{< tooltip >}}Corda CLI{{< /tooltip >}} | See [Installing the Corda CLI]({{< relref "../../tooling/installing-corda-cli.md" >}}) section. |
+| {{< tooltip >}}Corda CLI{{< /tooltip >}} | See [Installing the Corda CLI]({{< relref "../../tooling/installing-corda-cli.md" >}}). |
 
 ## Required CorDapp Template Ports
 

--- a/content/en/platform/corda/5.2/developing-applications/cordapp-template/prerequisites/_index.md
+++ b/content/en/platform/corda/5.2/developing-applications/cordapp-template/prerequisites/_index.md
@@ -28,7 +28,7 @@ The {{< version >}} CorDapp Template has been tested with the following:
 | Intellij                                 | ~v2021.x.y Community Edition                                        |
 | git                                      | ~v2.24.1                                                            |
 | Docker                                   | Docker Engine ~v20.x.y or Docker Desktop ~v3.5.x                    |
-| {{< tooltip >}}Corda CLI{{< /tooltip >}} |                                                                     |
+| {{< tooltip >}}Corda CLI{{< /tooltip >}} | See [Installing the Corda CLI]({{< relref "../../tooling/installing-corda-cli/installing-corda-cli.md" >}}) section. |
 
 ## Required CorDapp Template Ports
 


### PR DESCRIPTION
Preview: https://anna.preview.docs.r3.com/en/platform/corda/5.2/developing-applications/cordapp-template/prerequisites.html#software-prerequisites