### PR TITLE
ES-2709: bump Jquery version to 3.7.1

### DIFF
--- a/themes/doks/layouts/partials/footer/script-footer.html
+++ b/themes/doks/layouts/partials/footer/script-footer.html
@@ -103,7 +103,7 @@
 {{ end -}}
 
 {{ if eq .IsHome true }}
-<script type="text/javascript" src="//code.jquery.com/jquery-1.11.0.min.js"></script>
+<script type="text/javascript" src="//code.jquery.com/jquery-3.7.1.min.js"></script>
 <script type="text/javascript" src="//code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
 <script type="text/javascript" src="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
 <script type="text/javascript" src="/js/home.js"></script>


### PR DESCRIPTION
Verified jQuery is now on a newer version when inspecting the preview site.

Chrome DevTools console output:

```
> jQuery.fn.jquery
'3.7.1'
```