### PR TITLE
ENT-15659: Remove Oracle JDK from support matrix

### DIFF
--- a/content/en/platform/corda/1.6/cenm/cenm-support-matrix.md
+++ b/content/en/platform/corda/1.6/cenm/cenm-support-matrix.md
@@ -51,15 +51,9 @@ CENM currently supports the following databases:
 
 ## JDK support
 
-Corda Enterprise Network Manager 1.6+ has been tested and verified to work with **Oracle JDK 8 JVM 8u491** and **Azul Zulu Enterprise 8u492**. For the Azure deployment downloadable, go to [Azul Systems](https://www.azul.com/downloads/azure-only/zulu/).
+Corda Enterprise Network Manager 1.6+ has been tested and verified to work with **Azul Zulu Enterprise 8u492**. For the Azure deployment downloadable, go to [Azul Systems](https://www.azul.com/downloads/azure-only/zulu/).
 
 Other distributions of the [OpenJDK](https://openjdk.java.net/) are not officially supported, but should be compatible with Corda Enterprise Network Manager 1.6.
-
-{{< warning >}}
-In accordance with the [Oracle Java SE Support Roadmap](https://www.oracle.com/technetwork/java/java-se-support-roadmap.html)
-which outlines the end of public updates of Java SE 8 for commercial use, please ensure you have the correct Java support contract in place
-for your deployment needs.
-{{< /warning >}}
 
 ## Operating systems supported in production
 

--- a/content/en/platform/corda/1.7/cenm/cenm-support-matrix.md
+++ b/content/en/platform/corda/1.7/cenm/cenm-support-matrix.md
@@ -53,16 +53,9 @@ CENM currently supports the following databases:
 
 ## JDK support
 
-Corda Enterprise Network Manager 1.7 has been tested and verified to work with **Oracle JDK 17.0.19** and **Azul Zulu Enterprise 17.0.19**. For the Azure deployment downloadable, go to [Azul Systems](https://www.azul.com/downloads/azure-only/zulu/).
+Corda Enterprise Network Manager 1.7 has been tested and verified to work with **Azul Zulu Enterprise 17.0.19**. For the Azure deployment downloadable, go to [Azul Systems](https://www.azul.com/downloads/azure-only/zulu/).
 
 Other distributions of the [OpenJDK](https://openjdk.java.net/) are not officially supported, but should be compatible with Corda Enterprise Network Manager 1.7.
-
-{{< warning >}}
-In accordance with the [Oracle Java SE Support Roadmap](https://www.oracle.com/technetwork/java/java-se-support-roadmap.html)
-which outlines the end of public updates of Java SE 8 for commercial use, please ensure you have the correct Java support contract in place
-for your deployment needs.
-
-{{< /warning >}}
 
 ## Operating systems supported in production
 

--- a/content/en/platform/corda/4.11/community/release-platform-support-matrix.md
+++ b/content/en/platform/corda/4.11/community/release-platform-support-matrix.md
@@ -27,16 +27,10 @@ Experimental notaries, such as **Crash fault-tolerant** and **Byzantine fault-to
 
 ## JDK support
 
-Corda: Community Edition 4.11 has been tested and verified to work with **Oracle JDK 8 JVM 8u491** and **Azul Zulu Enterprise 8u492**, for Azure deployment downloadable from
+Corda: Community Edition 4.11 has been tested and verified to work with **Azul Zulu Enterprise 8u492**, for Azure deployment downloadable from
 [Azul Systems](https://www.azul.com/downloads/azure-only/zulu/).
 
 Other distributions of the [OpenJDK](https://openjdk.java.net/) are not officially supported but should be compatible with Corda Enterprise Edition 4.11.
-
-{{< warning >}}
-In accordance with the [Oracle Java SE Support Roadmap](https://www.oracle.com/technetwork/java/java-se-support-roadmap.html),
-which outlines the end of public updates of Java SE 8 for commercial use, please ensure you have the correct Java support contract in place
-for your deployment needs.
-{{< /warning >}}
 
 ## JDKs supported in development
 

--- a/content/en/platform/corda/4.11/enterprise/platform-support-matrix.md
+++ b/content/en/platform/corda/4.11/enterprise/platform-support-matrix.md
@@ -22,16 +22,10 @@ Corda Enterprise Edition supports a subset of the platforms that are supported b
 
 ### JDK support in production
 
-Corda Enterprise Edition 4.11 has been tested and verified to work with **Oracle JDK 8 JVM 8u492** and **Azul Zulu Enterprise 8u491**, for Azure deployment downloadable from
+Corda Enterprise Edition 4.11 has been tested and verified to work with **Azul Zulu Enterprise 8u492**, for Azure deployment downloadable from
 [Azul Systems](https://www.azul.com/downloads/azure-only/zulu/).
 
 Other distributions of the [OpenJDK](https://openjdk.java.net/) are not officially supported but should be compatible with Corda Enterprise Edition 4.11.
-
-{{< warning >}}
-In accordance with the [Oracle Java SE Support Roadmap](https://www.oracle.com/technetwork/java/java-se-support-roadmap.html),
-which outlines the end of public updates of Java SE 8 for commercial use, please ensure you have the correct Java support contract in place
-for your deployment needs.
-{{< /warning >}}
 
 ### JDK support in development
 
@@ -41,10 +35,10 @@ The following JDKs support Corda for development purposes. Corda does not curren
 
 | Supported JDKs                                                                   | Latest supported version |
 |----------------------------------------------------------------------------------|--------------------------|
-| [Oracle JDK](https://www.oracle.com/ie/java/technologies/downloads/)             | 8u492                    |
+| [Oracle JDK](https://www.oracle.com/ie/java/technologies/downloads/)             | 8u491                    |
 | [Amazon Corretto 8](https://aws.amazon.com/corretto/)                            | 8.252.09.1               |
 | [Red Hat OpenJDK](https://developers.redhat.com/products/openjdk/overview/)      | 8u322                    |
-| [Zulu OpenJDK](https://www.azul.com/)                                            | 8u491                    |
+| [Zulu OpenJDK](https://www.azul.com/)                                            | 8u492                    |
 
 {{< /table >}}
 

--- a/content/en/platform/corda/4.12/community/release-platform-support-matrix.md
+++ b/content/en/platform/corda/4.12/community/release-platform-support-matrix.md
@@ -27,7 +27,7 @@ Experimental notaries, such as **Crash fault-tolerant** and **Byzantine fault-to
 
 ## JDK support
 
-Corda Open Source Edition 4.12 has been tested and verified to work with **Oracle JDK 17.0.19** and **Azul Zulu Enterprise 17.0.19**.
+Corda Open Source Edition 4.12 has been tested and verified to work with **Azul Zulu Enterprise 17.0.19**.
 
 Other distributions of the [OpenJDK](https://openjdk.java.net/) are not officially supported but should be compatible with Corda Enterprise Edition 4.12.
 

--- a/content/en/platform/corda/4.12/enterprise/platform-support-matrix.md
+++ b/content/en/platform/corda/4.12/enterprise/platform-support-matrix.md
@@ -22,7 +22,7 @@ Corda Enterprise Edition supports a subset of the platforms that are supported b
 
 ### JDK support in production
 
-Corda Enterprise Edition 4.12 has been tested and verified to work with **Oracle JDK 17.0.19** and **Azul Zulu Enterprise 17.0.19**.
+Corda Enterprise Edition 4.12 has been tested and verified to work with **Azul Zulu Enterprise 17.0.19**.
 
 Other distributions of the [OpenJDK](https://openjdk.java.net/) are not officially supported but should be compatible with Corda Enterprise Edition 4.12.
 

--- a/content/en/platform/corda/4.13/community/release-platform-support-matrix.md
+++ b/content/en/platform/corda/4.13/community/release-platform-support-matrix.md
@@ -27,7 +27,7 @@ Experimental notaries, such as **Crash fault-tolerant** and **Byzantine fault-to
 
 ## JDK support
 
-Corda Open Source Edition 4.13 has been tested and verified to work with **Oracle JDK 17.0.19** and **Azul Zulu Enterprise 17.0.19**.
+Corda Open Source Edition 4.13 has been tested and verified to work with **Azul Zulu Enterprise 17.0.19**.
 
 Other distributions of the [OpenJDK](https://openjdk.java.net/) are not officially supported but should be compatible with Corda Enterprise Edition 4.11.
 

--- a/content/en/platform/corda/4.13/enterprise/platform-support-matrix.md
+++ b/content/en/platform/corda/4.13/enterprise/platform-support-matrix.md
@@ -22,7 +22,7 @@ Corda Enterprise Edition supports a subset of the platforms that are supported b
 
 ### JDK support in production
 
-Corda Enterprise Edition 4.13 has been tested and verified to work with **Oracle JDK 17.0.19** and **Azul Zulu Enterprise 17.0.19**.
+Corda Enterprise Edition 4.13 has been tested and verified to work with **Azul Zulu Enterprise 17.0.19**.
 
 Other distributions of the [OpenJDK](https://openjdk.java.net/) are not officially supported but should be compatible with Corda Enterprise Edition 4.13.
 

--- a/content/en/platform/corda/4.14/community/release-platform-support-matrix.md
+++ b/content/en/platform/corda/4.14/community/release-platform-support-matrix.md
@@ -27,7 +27,7 @@ Experimental notaries, such as **Crash fault-tolerant** and **Byzantine fault-to
 
 ## JDK support
 
-Corda Open Source Edition 4.14 has been tested and verified to work with **Oracle JDK 17.0.19** and **Azul Zulu Enterprise 17.0.19**.
+Corda Open Source Edition 4.14 has been tested and verified to work with **Azul Zulu Enterprise 17.0.19**.
 
 Other distributions of the [OpenJDK](https://openjdk.java.net/) are not officially supported but should be compatible with Corda Enterprise Edition 4.11.
 

--- a/content/en/platform/corda/4.14/enterprise/platform-support-matrix.md
+++ b/content/en/platform/corda/4.14/enterprise/platform-support-matrix.md
@@ -22,7 +22,7 @@ Corda Enterprise Edition supports a subset of the platforms that are supported b
 
 ### JDK support in production
 
-Corda Enterprise Edition 4.14 has been tested and verified to work with **Oracle JDK 17.0.19** and **Azul Zulu Enterprise 17.0.19**.
+Corda Enterprise Edition 4.14 has been tested and verified to work with **Azul Zulu Enterprise 17.0.19**.
 
 Other distributions of the [OpenJDK](https://openjdk.java.net/) are not officially supported but should be compatible with Corda Enterprise Edition 4.14.
 


### PR DESCRIPTION
As of the 13th of July, R3 won’t renew Oracle JDK licence, therefore it needs to be removed from the support matrix.

